### PR TITLE
Reorganize key names

### DIFF
--- a/js/admin/src/addTagPermission.js
+++ b/js/admin/src/addTagPermission.js
@@ -5,7 +5,7 @@ export default function() {
   extend(PermissionGrid.prototype, 'moderateItems', items => {
     items.add('tag', {
       icon: 'tag',
-      label: 'Tag discussions',
+      label: app.translator.trans('flarum-tags.admin.permissions.tag_discussions_label'),
       permission: 'discussion.tag'
     }, 95);
   });

--- a/js/admin/src/addTagsHomePageOption.js
+++ b/js/admin/src/addTagsHomePageOption.js
@@ -5,7 +5,7 @@ export default function() {
   extend(BasicsPage.prototype, 'homePageItems', items => {
     items.add('tags', {
       path: '/tags',
-      label: 'Tags'
+      label: app.translator.trans('flarum-tags.admin.basics.tags_label')
     });
   });
 }

--- a/js/admin/src/addTagsPane.js
+++ b/js/admin/src/addTagsPane.js
@@ -13,8 +13,8 @@ export default function() {
     items.add('tags', AdminLinkButton.component({
       href: app.route('tags'),
       icon: 'tags',
-      children: 'Tags',
-      description: 'Manage the list of tags available to organise discussions with.'
+      children: app.translator.trans('flarum-tags.admin.nav.tags_button'),
+      description: app.translator.trans('flarum-tags.admin.nav.tags_text')
     }));
   });
 }

--- a/js/admin/src/addTagsPermissionScope.js
+++ b/js/admin/src/addTagsPermissionScope.js
@@ -37,7 +37,7 @@ export default function() {
       items.add('tag', Dropdown.component({
         className: 'Dropdown--restrictByTag',
         buttonClassName: 'Button Button--text',
-        label: 'Restrict by Tag',
+        label: app.translator.trans('flarum-tags.admin.permissions.restrict_by_tag_heading'),
         icon: 'plus',
         caretIcon: null,
         children: tags.map(tag => Button.component({

--- a/js/admin/src/components/EditTagModal.js
+++ b/js/admin/src/components/EditTagModal.js
@@ -31,7 +31,7 @@ export default class EditTagModal extends Modal {
         name: this.name,
         color: this.color
       })
-      : 'Create Tag';
+      : app.translator.trans('flarum-tags.admin.edit_tag.title');
   }
 
   content() {
@@ -39,25 +39,25 @@ export default class EditTagModal extends Modal {
       <div className="Modal-body">
         <div className="Form">
           <div className="Form-group">
-            <label>Name</label>
-            <input className="FormControl" placeholder="Name" value={this.name()} oninput={e => {
+            <label>{app.translator.trans('flarum-tags.admin.edit_tag.name_label')}</label>
+            <input className="FormControl" placeholder={app.translator.trans('flarum-tags.admin.edit_tag.name_placeholder')} value={this.name()} oninput={e => {
               this.name(e.target.value);
               this.slug(slug(e.target.value));
             }}/>
           </div>
 
           <div className="Form-group">
-            <label>Slug</label>
+            <label>{app.translator.trans('flarum-tags.admin.edit_tag.slug_label')}</label>
             <input className="FormControl" value={this.slug()} oninput={m.withAttr('value', this.slug)}/>
           </div>
 
           <div className="Form-group">
-            <label>Description</label>
+            <label>{app.translator.trans('flarum-tags.admin.edit_tag.description_label')}</label>
             <textarea className="FormControl" value={this.description()} oninput={m.withAttr('value', this.description)}/>
           </div>
 
           <div className="Form-group">
-            <label>Color</label>
+            <label>{app.translator.trans('flarum-tags.admin.edit_tag.color_label')}</label>
             <input className="FormControl" placeholder="#aaaaaa" value={this.color()} oninput={m.withAttr('value', this.color)}/>
           </div>
 
@@ -65,7 +65,7 @@ export default class EditTagModal extends Modal {
             <div>
               <label className="checkbox">
                 <input type="checkbox" value="1" checked={this.isHidden()} onchange={m.withAttr('checked', this.isHidden)}/>
-                Hide from All Discussions
+                {app.translator.trans('flarum-tags.admin.edit_tag.hide_label')}
               </label>
             </div>
           </div>
@@ -75,11 +75,11 @@ export default class EditTagModal extends Modal {
               type: 'submit',
               className: 'Button Button--primary EditTagModal-save',
               loading: this.loading,
-              children: 'Save Changes'
+              children: app.translator.trans('flarum-tags.admin.edit_tag.submit_button')
             })}
             {this.tag.exists ? (
               <button type="button" className="Button EditTagModal-delete" onclick={this.delete.bind(this)}>
-                Delete Tag
+                {app.translator.trans('flarum-tags.admin.edit_tag.delete_tag_button')}
               </button>
             ) : ''}
           </div>
@@ -109,7 +109,7 @@ export default class EditTagModal extends Modal {
   }
 
   delete() {
-    if (confirm('Are you sure you want to delete this tag? The tag\'s discussions will NOT be deleted.')) {
+    if (confirm(app.translator.trans('flarum-tags.admin.edit_tag.delete_tag_confirmation'))) {
       this.tag.delete().then(() => m.redraw());
       this.hide();
     }

--- a/js/admin/src/components/TagSettingsModal.js
+++ b/js/admin/src/components/TagSettingsModal.js
@@ -11,7 +11,7 @@ export default class TagSettingsModal extends SettingsModal {
   }
 
   title() {
-    return 'Tag Settings';
+    return app.translator.trans('flarum-tags.admin.tag_settings.title');
   }
 
   form() {
@@ -23,9 +23,9 @@ export default class TagSettingsModal extends SettingsModal {
 
     return [
       <div className="Form-group">
-        <label>Required Number of Primary Tags</label>
+        <label>{app.translator.trans('flarum-tags.admin.tag_settings.required_primary_heading')}</label>
         <div className="helpText">
-          Enter the minimum and maximum number of primary tags that may be applied to a discussion.
+          {app.translator.trans('flarum-tags.admin.tag_settings.required_primary_text')}
         </div>
         <div className="TagSettingsModal-rangeInput">
           <input className="FormControl"
@@ -33,7 +33,7 @@ export default class TagSettingsModal extends SettingsModal {
             min="0"
             value={minPrimaryTags()}
             oninput={m.withAttr('value', this.setMinTags.bind(this, minPrimaryTags, maxPrimaryTags))} />
-          {' to '}
+          {app.translator.trans('flarum-tags.admin.tag_settings.range_separator_text')}
           <input className="FormControl"
             type="number"
             min={minPrimaryTags()}
@@ -42,9 +42,9 @@ export default class TagSettingsModal extends SettingsModal {
       </div>,
 
       <div className="Form-group">
-        <label>Required Number of Secondary Tags</label>
+        <label>{app.translator.trans('flarum-tags.admin.tag_settings.required_secondary_heading')}</label>
         <div className="helpText">
-          Enter the minimum and maximum number of secondary tags that may be applied to a discussion.
+          {app.translator.trans('flarum-tags.admin.tag_settings.required_secondary_text')}
         </div>
         <div className="TagSettingsModal-rangeInput">
           <input className="FormControl"
@@ -52,7 +52,7 @@ export default class TagSettingsModal extends SettingsModal {
             min="0"
             value={minSecondaryTags()}
             oninput={m.withAttr('value', this.setMinTags.bind(this, minSecondaryTags, maxSecondaryTags))} />
-          {' to '}
+          {app.translator.trans('flarum-tags.admin.tag_settings.range_separator_text')}
           <input className="FormControl"
             type="number"
             min={minSecondaryTags()}

--- a/js/admin/src/components/TagsPage.js
+++ b/js/admin/src/components/TagsPage.js
@@ -36,17 +36,17 @@ export default class TagsPage extends Component {
         <div className="TagsPage-header">
           <div className="container">
             <p>
-              Tags are used to categorize discussions. Primary tags are like traditional forum categories: They can be arranged in a two-level hierarchy. Secondary tags do not have hierarchy or order, and are useful for micro-categorization.
+              {app.translator.trans('flarum-tags.admin.tags.about_tags_text')}
             </p>
             {Button.component({
               className: 'Button Button--primary',
               icon: 'plus',
-              children: 'Create Tag',
+              children: app.translator.trans('flarum-tags.admin.tags.create_tag_button'),
               onclick: () => app.modal.show(new EditTagModal())
             })}
             {Button.component({
               className: 'Button',
-              children: 'Settings',
+              children: app.translator.trans('flarum-tags.admin.tags.settings_button'),
               onclick: () => app.modal.show(new TagSettingsModal())
             })}
           </div>
@@ -54,7 +54,7 @@ export default class TagsPage extends Component {
         <div className="TagsPage-list">
           <div className="container">
             <div className="TagGroup">
-              <label>Primary Tags</label>
+              <label>{app.translator.trans('flarum-tags.admin.tags.primary_heading')}</label>
               <ol className="TagList TagList--primary">
                 {sortTags(app.store.all('tags'))
                   .filter(tag => tag.position() !== null && !tag.isChild())
@@ -63,7 +63,7 @@ export default class TagsPage extends Component {
             </div>
 
             <div className="TagGroup">
-              <label>Secondary Tags</label>
+              <label>{app.translator.trans('flarum-tags.admin.tags.secondary_heading')}</label>
               <ul className="TagList">
                 {app.store.all('tags')
                   .filter(tag => tag.position() === null)

--- a/js/forum/src/addTagComposer.js
+++ b/js/forum/src/addTagComposer.js
@@ -35,7 +35,7 @@ export default function() {
       <a className="DiscussionComposer-changeTags" onclick={this.chooseTags.bind(this)}>
         {this.tags.length
           ? tagsLabel(this.tags)
-          : <span className="TagLabel untagged">{app.translator.trans('flarum-tags.forum.tag_new_discussion_link')}</span>}
+          : <span className="TagLabel untagged">{app.translator.trans('flarum-tags.forum.composer_discussion.choose_tags_link')}</span>}
       </a>
     ), 10);
   });

--- a/js/forum/src/addTagControl.js
+++ b/js/forum/src/addTagControl.js
@@ -9,7 +9,7 @@ export default function() {
   extend(DiscussionControls, 'moderationControls', function(items, discussion) {
     if (discussion.canTag()) {
       items.add('tags', Button.component({
-        children: app.translator.trans('flarum-tags.forum.edit_discussion_tags_link'),
+        children: app.translator.trans('flarum-tags.forum.discussion_controls.edit_tags_button'),
         icon: 'tag',
         onclick: () => app.modal.show(new TagDiscussionModal({discussion}))
       }));

--- a/js/forum/src/addTagList.js
+++ b/js/forum/src/addTagList.js
@@ -13,7 +13,7 @@ export default function() {
   extend(IndexPage.prototype, 'navItems', function(items) {
     items.add('tags', LinkButton.component({
       icon: 'th-large',
-      children: app.translator.trans('flarum-tags.forum.tags'),
+      children: app.translator.trans('flarum-tags.forum.index.tags_link'),
       href: app.route('tags')
     }), -10);
 
@@ -47,7 +47,7 @@ export default function() {
 
     if (more.length) {
       items.add('moreTags', LinkButton.component({
-        children: app.translator.trans('flarum-tags.forum.more'),
+        children: app.translator.trans('flarum-tags.forum.index.more_link'),
         href: app.route('tags')
       }), -10);
     }

--- a/js/forum/src/components/DiscussionTaggedPost.js
+++ b/js/forum/src/components/DiscussionTaggedPost.js
@@ -7,6 +7,12 @@ export default class DiscussionTaggedPost extends EventPost {
     return 'tag';
   }
 
+  // NEED TO FIX:
+  // This should return one of three strings, depending on whether tags are added, removed, or both:
+  //   if added: app.translator.trans('flarum-tags.forum.post_stream.added_tags_text')
+  //   if removed: app.translator.trans('flarum-tags.forum.post_stream.removed_tags_text')
+  //   if both: app.translator.trans('flarum-tags.forum.post_stream.added_and_removed_tags_text')
+  // The 'flarum-tags.forum.discussion_tagged_post' key has been removed from the YAML.
   descriptionKey() {
     return 'flarum-tags.forum.discussion_tagged_post';
   }
@@ -26,15 +32,18 @@ export default class DiscussionTaggedPost extends EventPost {
     const removed = diffTags(oldTags, newTags);
     const actions = [];
 
+    // PLEASE CHECK:
+    // Both {addedTags} and {removedTags} in the above three strings can be returned using the same key.
+    // The key names has been changed ... Is it possible to combine these two operations?
     if (added.length) {
-      actions.push(app.translator.transChoice('flarum-tags.forum.added_tags', added, {
+      actions.push(app.translator.transChoice('flarum-tags.forum.post_stream.tags_text', added, {
         tags: tagsLabel(added, {link: true}),
         count: added
       }));
     }
 
     if (removed.length) {
-      actions.push(app.translator.transChoice('flarum-tags.forum.removed_tags', removed, {
+      actions.push(app.translator.transChoice('flarum-tags.forum.post_stream.tags_text', removed, {
         tags: tagsLabel(removed, {link: true}),
         count: removed
       }));

--- a/js/forum/src/components/TagDiscussionModal.js
+++ b/js/forum/src/components/TagDiscussionModal.js
@@ -85,17 +85,17 @@ export default class TagDiscussionModal extends Modal {
 
   title() {
     return this.props.discussion
-      ? app.translator.trans('flarum-tags.forum.edit_discussion_tags_title', {title: <em>{this.props.discussion.title()}</em>})
-      : app.translator.trans('flarum-tags.forum.tag_new_discussion_title');
+      ? app.translator.trans('flarum-tags.forum.choose_tags.edit_title', {title: <em>{this.props.discussion.title()}</em>})
+      : app.translator.trans('flarum-tags.forum.choose_tags.title');
   }
 
   getInstruction(primaryCount, secondaryCount) {
     if (primaryCount < this.minPrimary) {
       const remaining = this.minPrimary - primaryCount;
-      return app.translator.transChoice('flarum-tags.forum.choose_primary_tags', remaining, {count: remaining});
+      return app.translator.transChoice('flarum-tags.forum.choose_tags.choose_primary_placeholder', remaining, {count: remaining});
     } else if (secondaryCount < this.minSecondary) {
       const remaining = this.minSecondary - secondaryCount;
-      return app.translator.transChoice('flarum-tags.forum.choose_secondary_tags', remaining, {count: remaining});
+      return app.translator.transChoice('flarum-tags.forum.choose_tags.choose_secondary_placeholder', remaining, {count: remaining});
     }
 
     return '';
@@ -162,7 +162,7 @@ export default class TagDiscussionModal extends Modal {
               className: 'Button Button--primary',
               disabled: primaryCount < this.minPrimary || secondaryCount < this.minSecondary,
               icon: 'check',
-              children: app.translator.trans('flarum-tags.forum.confirm')
+              children: app.translator.trans('flarum-tags.forum.choose_tags.submit_button')
             })}
           </div>
         </div>

--- a/js/forum/src/components/TagLinkButton.js
+++ b/js/forum/src/components/TagLinkButton.js
@@ -22,6 +22,6 @@ export default class TagLinkButton extends LinkButton {
 
     props.params.tags = tag ? tag.slug() : 'untagged';
     props.href = app.route('tag', props.params);
-    props.children = tag ? tag.name() : app.translator.trans('flarum-tags.forum.untagged');
+    props.children = tag ? tag.name() : app.translator.trans('flarum-tags.forum.index.untagged_link');
   }
 }

--- a/js/lib/helpers/tagLabel.js
+++ b/js/lib/helpers/tagLabel.js
@@ -25,7 +25,7 @@ export default function tagLabel(tag, attrs = {}) {
   return (
     m((link ? 'a' : 'span'), attrs,
       <span className="TagLabel-text">
-        {tag ? tag.name() : app.translator.trans('flarum-tags.forum.deleted')}
+        {tag ? tag.name() : app.translator.trans('flarum-tags.lib.deleted_tag_text')}
       </span>
     )
   );


### PR DESCRIPTION
See [flarum/core #265](https://github.com/flarum/core/issues/265).

- Adjusts key names to three-tier namespacing.
- Extracts previously unextracted strings.
- Code fix needed in DiscussionTaggedPost.js before this can be used.