### PR TITLE
Added default <meta> description for tags

### DIFF
--- a/bootstrap.php
+++ b/bootstrap.php
@@ -13,6 +13,7 @@ use Flarum\Extend;
 use Flarum\Forum\Controller\FrontendController;
 use Flarum\Tags\Access;
 use Flarum\Tags\Api\Controller;
+use Flarum\Tags\Forum\Controller\TagController;
 use Flarum\Tags\Listener;
 use Illuminate\Contracts\Events\Dispatcher;
 
@@ -26,7 +27,7 @@ return [
         ->asset(__DIR__.'/less/admin/extension.less')
         ->bootstrapper('flarum/tags/main'),
     (new Extend\Routes('forum'))
-        ->get('/t/{slug}', 'tag', FrontendController::class)
+        ->get('/t/{slug}', 'tag', TagController::class)
         ->get('/tags', 'tags', FrontendController::class),
     (new Extend\Routes('api'))
         ->get('/tags', 'tags.index', Controller\ListTagsController::class)

--- a/js/forum/src/components/TagHero.js
+++ b/js/forum/src/components/TagHero.js
@@ -7,7 +7,10 @@ export default class TagHero extends Component {
     app.setTitle(tag.name());
     let description = tag.description();
     if (!description) {
-      description = app.translator.trans('flarum-tags.forum.meta_description.discussions_tagged_text', { tag: tag.name() }).join('');
+      description = app.translator.trans('flarum-tags.forum.meta_description.discussions_tagged_text', { tag: tag.name() });
+      if (description.constructor === Array) {
+        description = description.join('');
+      }
     }
     app.setDescription(description);
 

--- a/js/forum/src/components/TagHero.js
+++ b/js/forum/src/components/TagHero.js
@@ -4,6 +4,12 @@ export default class TagHero extends Component {
   view() {
     const tag = this.props.tag;
     const color = tag.color();
+    app.setTitle(tag.name());
+    let description = tag.description();
+    if (!description) {
+      description = app.translator.trans('flarum-tags.forum.meta_description.discussions_tagged_text', { tag: tag.name() }).join('');
+    }
+    app.setDescription(description);
 
     return (
       <header className={'Hero TagHero' + (color ? ' TagHero--colored' : '')}

--- a/js/forum/src/components/TagsPage.js
+++ b/js/forum/src/components/TagsPage.js
@@ -20,6 +20,8 @@ export default class TagsPage extends Component {
   view() {
     const pinned = this.tags.filter(tag => tag.position() !== null);
     const cloud = this.tags.filter(tag => tag.position() === null);
+    app.setTitle('');
+    app.setDescription('');
 
     return (
       <div className="TagsPage">

--- a/src/Forum/Controller/TagController.php
+++ b/src/Forum/Controller/TagController.php
@@ -1,0 +1,58 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Tags\Forum\Controller;
+
+use Flarum\Forum\Controller\FrontendController;
+use Flarum\Forum\Frontend;
+use Flarum\Foundation\Application;
+use Flarum\Tags\TagRepository;
+use Illuminate\Contracts\Events\Dispatcher;
+use Psr\Http\Message\ServerRequestInterface as Request;
+use Symfony\Component\Translation\TranslatorInterface;
+
+class TagController extends FrontendController
+{
+    /**
+     * @var TagRepository
+     */
+    protected $tags;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function __construct(Frontend $webApp, Dispatcher $events, TagRepository $tags)
+    {
+        parent::__construct($webApp, $events);
+        $this->tags = $tags;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function getView(Request $request)
+    {
+        $view = parent::getView($request);
+        $id = $this->tags->getIdForSlug(array_get($request->getQueryParams(), 'slug'));
+        $actor = $request->getAttribute('actor');
+        $tag = $this->tags->findOrFail($id, $actor);
+
+        $description = $tag->description;
+        if ($description == null) {
+            $app = Application::getInstance();
+            $translator = $app->make(TranslatorInterface::class);
+            $description = $translator->trans('flarum-tags.forum.meta_description.discussions_tagged_text', ['{tag}' => $tag->name]);
+        }
+        $view->description = $description;
+
+        return $view;
+    }
+}

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -220,4 +220,19 @@ class Tag extends AbstractModel
     {
         return static::getIdsWherePermission($user, $permission, false);
     }
+
+    /**
+     * Get the description.
+     *
+     * Returns the stored description (if any).
+     *
+     * @param string $description
+     * @return string
+     */
+    protected function getDescriptionAttribute($description)
+    {
+        $description = ($description == null) ? '' : $description;
+
+        return $description;
+    }
 }

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -220,19 +220,4 @@ class Tag extends AbstractModel
     {
         return static::getIdsWherePermission($user, $permission, false);
     }
-
-    /**
-     * Get the description.
-     *
-     * Returns the stored description (if any).
-     *
-     * @param string $description
-     * @return string
-     */
-    protected function getDescriptionAttribute($description)
-    {
-        $description = ($description == null) ? '' : $description;
-
-        return $description;
-    }
 }

--- a/src/TagRepository.php
+++ b/src/TagRepository.php
@@ -67,7 +67,7 @@ class TagRepository
     {
         $query = Tag::where('slug', 'like', $slug);
 
-        return $this->scopeVisibleTo($query, $user)->pluck('id');
+        return $this->scopeVisibleTo($query, $user)->value('id');
     }
 
     /**


### PR DESCRIPTION
Continuing the work on flarum/core#1385, this is adding the <meta> description for tags. If a tag does not have a description, it would default to _"Discussions with the '{tag}' tag"_.