### PR TITLE
Do not hide tags from Following (subscriptions)

### DIFF
--- a/src/Listener/FilterDiscussionListByTags.php
+++ b/src/Listener/FilterDiscussionListByTags.php
@@ -13,6 +13,7 @@ namespace Flarum\Tags\Listener;
 
 use Flarum\Discussion\Event\Searching;
 use Flarum\Event\ConfigureDiscussionGambits;
+use Flarum\Subscriptions\Gambit\SubscriptionGambit;
 use Flarum\Tags\Gambit\TagGambit;
 use Flarum\Tags\Tag;
 use Illuminate\Contracts\Events\Dispatcher;
@@ -44,7 +45,7 @@ class FilterDiscussionListByTags
         $query = $event->search->getQuery();
 
         foreach ($event->search->getActiveGambits() as $gambit) {
-            if ($gambit instanceof TagGambit) {
+            if ($gambit instanceof TagGambit || $gambit instanceof SubscriptionGambit) {
                 return;
             }
         }

--- a/src/Listener/FilterDiscussionListByTags.php
+++ b/src/Listener/FilterDiscussionListByTags.php
@@ -44,10 +44,8 @@ class FilterDiscussionListByTags
     {
         $query = $event->search->getQuery();
 
-        foreach ($event->search->getActiveGambits() as $gambit) {
-            if ($gambit instanceof TagGambit || $gambit instanceof SubscriptionGambit) {
-                return;
-            }
+        if (count($event->search->getActiveGambits()) > 0) {
+            return;
         }
 
         $query->whereNotExists(function ($query) {

--- a/src/Listener/FilterDiscussionListByTags.php
+++ b/src/Listener/FilterDiscussionListByTags.php
@@ -13,7 +13,6 @@ namespace Flarum\Tags\Listener;
 
 use Flarum\Discussion\Event\Searching;
 use Flarum\Event\ConfigureDiscussionGambits;
-use Flarum\Subscriptions\Gambit\SubscriptionGambit;
 use Flarum\Tags\Gambit\TagGambit;
 use Flarum\Tags\Tag;
 use Illuminate\Contracts\Events\Dispatcher;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes flarum/core#1232**

**Changes proposed in this pull request:**
- ~~Do not hide discussions with hidden tag if `SubscriptionGambit` is used~~
  - ~~Note: No error is thrown if flarum/flarum-ext-subscriptions is not enabled~~
- Do not hide discussions with hidden tag if any gambit is used

**Reviewers should focus on:**
- ~~Maybe we need a way to let extensions extend the list of gambits to ignore~~

**Screenshot**
![image](https://user-images.githubusercontent.com/6401250/46564918-871b3b00-c8d8-11e8-8dae-54d7025dbb0d.png)
![image](https://user-images.githubusercontent.com/6401250/46564915-82568700-c8d8-11e8-98e5-d3f57de0fd4a.png)

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `php vendor/bin/phpunit`).