### PR TITLE
Update code to work with latest html5sortable

### DIFF
--- a/js/package-lock.json
+++ b/js/package-lock.json
@@ -2779,9 +2779,9 @@
       }
     },
     "html5sortable": {
-      "version": "0.9.8",
-      "resolved": "https://registry.npmjs.org/html5sortable/-/html5sortable-0.9.8.tgz",
-      "integrity": "sha512-QodBiv8LdTZHot3EMzNHTeKn/nHm66BlvmcFvMFMPVm4mYN5S0uKvDxFnzRltFvrIjvps7OVRrxBJQX8aLnxWg=="
+      "version": "0.9.16",
+      "resolved": "https://registry.npmjs.org/html5sortable/-/html5sortable-0.9.16.tgz",
+      "integrity": "sha512-GjCFl7w+Z6bQNs6lU5fhPqLoC5aRbFbQtL9rgqGR3Fs0GCRCrGjoRusZkhWaQpMr4eN25BlkviYA2nH+hFnDoA=="
     },
     "https-browserify": {
       "version": "1.0.0",

--- a/js/package.json
+++ b/js/package.json
@@ -3,7 +3,7 @@
   "name": "@flarum/tags",
   "dependencies": {
     "flarum-webpack-config": "0.1.0-beta.10",
-    "html5sortable": "^0.9.8",
+    "html5sortable": "^0.9.16",
     "webpack": "^4.26.0",
     "webpack-cli": "^3.1.2"
   },

--- a/js/src/admin/components/TagsPage.js
+++ b/js/src/admin/components/TagsPage.js
@@ -80,7 +80,13 @@ export default class TagsPage extends Page {
   }
 
   config() {
-    const cb = el => el.addEventListener('sortupdate', (e) => {
+    sortable(this.$('ol, ul'), {
+      acceptFrom: 'ol,ul'
+    }).forEach(this.onSortUpdate.bind(this));
+  }
+
+  onSortUpdate(el) {
+    el.addEventListener('sortupdate', (e) => {
       // If we've moved a tag from 'primary' to 'secondary', then we'll update
       // its attributes in our local store so that when we redraw the change
       // will be made.
@@ -143,9 +149,5 @@ export default class TagsPage extends Page {
       m.redraw.strategy('all');
       m.redraw();
     });
-
-    sortable(this.$('ol, ul'), {
-      acceptFrom: 'ol,ul'
-    }).forEach(cb);
   }
 }

--- a/js/src/admin/components/TagsPage.js
+++ b/js/src/admin/components/TagsPage.js
@@ -1,4 +1,4 @@
-import 'html5sortable';
+import sortable from 'html5sortable/dist/html5sortable.es.js';
 
 import Page from 'flarum/components/Page';
 import Button from 'flarum/components/Button';
@@ -80,14 +80,15 @@ export default class TagsPage extends Page {
   }
 
   config() {
-    this.$('ol, ul')
-      .sortable({connectWith: 'primary'})
-      .on('sortupdate', (e, ui) => {
+    sortable(this.$('ol, ul'), {
+      acceptFrom: 'ol,ul'
+    }).forEach(el =>
+      el.addEventListener('sortupdate', (e) => {
         // If we've moved a tag from 'primary' to 'secondary', then we'll update
         // its attributes in our local store so that when we redraw the change
         // will be made.
-        if (ui.startparent.is('ol') && ui.endparent.is('ul')) {
-          app.store.getById('tags', ui.item.data('id')).pushData({
+        if (e.detail.origin.container instanceof HTMLOListElement && e.detail.destination.container instanceof HTMLUListElement) {
+          app.store.getById('tags', e.detail.item.getAttribute('data-id')).pushData({
             attributes: {
               position: null,
               isChild: false
@@ -144,6 +145,7 @@ export default class TagsPage extends Page {
         // we force a full reconstruction of the DOM.
         m.redraw.strategy('all');
         m.redraw();
-      });
+      })
+    );
   }
 }


### PR DESCRIPTION
Fixes flarum/core#1786

- Updated `import` statement, uses ES6 dist file
- Use `forEach` to add `sortupdate` event listener
- Check primary -> secondary by looking at element constructors
    - `ol` => `HTMLOListElement`
    - `ul` => `HTMLUListElement`
- Get data attribute through vanilla JS