### PR TITLE
Fix default value for useColor overriding falsy values

### DIFF
--- a/js/src/common/helpers/tagIcon.js
+++ b/js/src/common/helpers/tagIcon.js
@@ -1,6 +1,6 @@
 export default function tagIcon(tag, attrs = {}, settings = {}) {
   const hasIcon = tag && tag.icon();
-  const useColor = settings.useColor || true;
+  const useColor = settings.useColor != null ? settings.useColor : true;
 
   attrs.className = hasIcon ? 'icon ' + tag.icon() + ' ' + (attrs.className || '') : 'icon TagIcon ' + (attrs.className || '');
 

--- a/js/src/common/helpers/tagIcon.js
+++ b/js/src/common/helpers/tagIcon.js
@@ -1,6 +1,6 @@
 export default function tagIcon(tag, attrs = {}, settings = {}) {
   const hasIcon = tag && tag.icon();
-  const useColor = settings.useColor != null ? settings.useColor : true;
+  const { useColor = true } = settings;
 
   attrs.className = hasIcon ? 'icon ' + tag.icon() + ' ' + (attrs.className || '') : 'icon TagIcon ' + (attrs.className || '');
 


### PR DESCRIPTION
This would make the 'useColor' setting irrelevant as it would always be true.
Error is noticeable in the discussion list when the icons are the same color as the tag background.

Caused by 12acf03f4bfbd5fb45173aebc7a6966be1c09ce9.

`false` does not soft equal `null`, so we can use `!= null` to check if it is provided without having a whole if block.