### PR TITLE
Add view & frontend documents for tags & tag discussion list 

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -24,7 +24,7 @@ return [
         ->js(__DIR__.'/js/dist/forum.js')
         ->css(__DIR__.'/less/forum.less')
         ->route('/t/{slug}', 'tag', Content\Tag::class)
-        ->route('/tags', 'tags'),
+        ->route('/tags', 'tags', Content\Tags::class),
 
     (new Extend\Frontend('admin'))
         ->js(__DIR__.'/js/dist/admin.js')

--- a/extend.php
+++ b/extend.php
@@ -14,14 +14,16 @@ use Flarum\Discussion\Event\Saving;
 use Flarum\Extend;
 use Flarum\Tags\Access;
 use Flarum\Tags\Api\Controller;
+use Flarum\Tags\Content;
 use Flarum\Tags\Listener;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Contracts\View\Factory;
 
 return [
     (new Extend\Frontend('forum'))
         ->js(__DIR__.'/js/dist/forum.js')
         ->css(__DIR__.'/less/forum.less')
-        ->route('/t/{slug}', 'tag')
+        ->route('/t/{slug}', 'tag', Content\Tag::class)
         ->route('/tags', 'tags'),
 
     (new Extend\Frontend('admin'))
@@ -35,7 +37,7 @@ return [
         ->patch('/tags/{id}', 'tags.update', Controller\UpdateTagController::class)
         ->delete('/tags/{id}', 'tags.delete', Controller\DeleteTagController::class),
 
-    function (Dispatcher $events) {
+    function (Dispatcher $events, Factory $view) {
         $events->subscribe(Listener\AddDiscussionTagsRelationship::class);
 
         $events->subscribe(Listener\AddForumTagsRelationship::class);
@@ -51,5 +53,7 @@ return [
         $events->subscribe(Access\DiscussionPolicy::class);
         $events->subscribe(Access\TagPolicy::class);
         $events->subscribe(Access\FlagPolicy::class);
+
+        $view->addNamespace('tags', __DIR__.'/views');
     },
 ];

--- a/src/Content/Tag.php
+++ b/src/Content/Tag.php
@@ -14,11 +14,9 @@ namespace Flarum\Tags\Content;
 use Flarum\Api\Client;
 use Flarum\Api\Controller\ListDiscussionsController;
 use Flarum\Frontend\Document;
-use Flarum\Http\Exception\RouteNotFoundException;
 use Flarum\Tags\TagRepository;
 use Flarum\User\User;
 use Illuminate\Contracts\View\Factory;
-use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface as Request;
 

--- a/src/Content/Tag.php
+++ b/src/Content/Tag.php
@@ -62,12 +62,8 @@ class Tag
 
         $sortMap = $this->getSortMap();
 
-        try {
-            $tagId = $this->tags->getIdForSlug($slug);
-            $tag = $this->tags->findOrFail($tagId, $actor);
-        } catch (ModelNotFoundException $e) {
-            throw new RouteNotFoundException;
-        }
+        $tagId = $this->tags->getIdForSlug($slug);
+        $tag = $this->tags->findOrFail($tagId, $actor);
 
         $params = [
             'sort' => $sort && isset($sortMap[$sort]) ? $sortMap[$sort] : '',

--- a/src/Content/Tag.php
+++ b/src/Content/Tag.php
@@ -1,0 +1,114 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Tags\Content;
+
+use Flarum\Api\Client;
+use Flarum\Api\Controller\ListDiscussionsController;
+use Flarum\Frontend\Document;
+use Flarum\Http\Exception\RouteNotFoundException;
+use Flarum\Tags\TagRepository;
+use Flarum\User\User;
+use Illuminate\Contracts\View\Factory;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+use Illuminate\Support\Arr;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class Tag
+{
+    /**
+     * @var Client
+     */
+    protected $api;
+
+    /**
+     * @var Factory
+     */
+    protected $view;
+
+    /**
+     * @var TagRepository
+     */
+    protected $tags;
+
+    /**
+     * @param Client $api
+     * @param Factory $view
+     */
+    public function __construct(Client $api, Factory $view, TagRepository $tags)
+    {
+        $this->api = $api;
+        $this->view = $view;
+        $this->tags = $tags;
+    }
+
+    public function __invoke(Document $document, Request $request)
+    {
+        $queryParams = $request->getQueryParams();
+        $actor = $request->getAttribute('actor');
+
+        $slug = Arr::pull($queryParams, 'slug');
+        $sort = Arr::pull($queryParams, 'sort');
+        $q = Arr::pull($queryParams, 'q', '');
+        $page = Arr::pull($queryParams, 'page', 1);
+
+        $sortMap = $this->getSortMap();
+
+        try {
+            $tagId = $this->tags->getIdForSlug($slug);
+            $tag = $this->tags->findOrFail($tagId, $actor);
+        } catch (ModelNotFoundException $e) {
+            throw new RouteNotFoundException;
+        }
+
+        $params = [
+            'sort' => $sort && isset($sortMap[$sort]) ? $sortMap[$sort] : '',
+            'filter' => [
+                'q' => "$q tag:$slug"
+            ],
+            'page' => ['offset' => ($page - 1) * 20, 'limit' => 20]
+        ];
+
+        $apiDocument = $this->getApiDocument($actor, $params);
+
+        $document->content = $this->view->make('tags::frontend.content.tag', compact('apiDocument', 'page', 'tag'));
+        $document->payload['apiDocument'] = $apiDocument;
+
+        return $document;
+    }
+
+    /**
+     * Get a map of sort query param values and their API sort params.
+     *
+     * @return array
+     */
+    private function getSortMap()
+    {
+        return [
+            'latest' => '-lastPostedAt',
+            'top' => '-commentCount',
+            'newest' => '-createdAt',
+            'oldest' => 'createdAt'
+        ];
+    }
+
+    /**
+     * Get the result of an API request to list discussions.
+     *
+     * @param User $actor
+     * @param array $params
+     * @return object
+     */
+    private function getApiDocument(User $actor, array $params)
+    {
+        return json_decode($this->api->send(ListDiscussionsController::class, $actor, $params)->getBody());
+    }
+}

--- a/src/Content/Tags.php
+++ b/src/Content/Tags.php
@@ -13,6 +13,8 @@ namespace Flarum\Tags\Content;
 
 use Flarum\Api\Client;
 use Flarum\Frontend\Document;
+use Flarum\Http\UrlGenerator;
+use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Tags\TagRepository;
 use Illuminate\Contracts\View\Factory;
 use Psr\Http\Message\ServerRequestInterface as Request;
@@ -35,21 +37,38 @@ class Tags
     protected $tags;
 
     /**
+     * @var SettingsRepositoryInterface
+     */
+    protected $settings;
+
+    /**
+     * @var UrlGenerator
+     */
+    protected $url;
+
+    /**
      * @param Client $api
      * @param Factory $view
+     * @param TagRepository $tags
+     * @param SettingsRepositoryInterface $settings
+     * @param UrlGenerator $url
      */
-    public function __construct(Client $api, Factory $view, TagRepository $tags)
+    public function __construct(Client $api, Factory $view, TagRepository $tags, SettingsRepositoryInterface $settings, UrlGenerator $url)
     {
         $this->api = $api;
         $this->view = $view;
         $this->tags = $tags;
+        $this->settings = $settings;
+        $this->url = $url;
     }
 
     public function __invoke(Document $document, Request $request)
     {
         $tags = collect($document->payload['resources'])->where('type', 'tags');
+        $defaultRoute = $this->settings->get('default_route');
 
         $document->content = $this->view->make('tags::frontend.content.tags', compact('tags'));
+        $document->canonicalUrl = $defaultRoute === '/tags' ? $this->url->to('forum')->base() : $request->getUri()->withQuery('');
 
         return $document;
     }

--- a/src/Content/Tags.php
+++ b/src/Content/Tags.php
@@ -66,8 +66,8 @@ class Tags
     {
         $tags = collect($document->payload['resources'])->where('type', 'tags');
         $childTags = $tags->where('attributes.isChild', true);
-        $primaryTags = $tags->where('attributes.isChild', false)->where('attributes.position', '!==', NULL)->sortBy('attributes.position');
-        $secondaryTags = $tags->where('attributes.isChild', false)->where('attributes.position', '===', NULL)->sortBy('attributes.name');
+        $primaryTags = $tags->where('attributes.isChild', false)->where('attributes.position', '!==', null)->sortBy('attributes.position');
+        $secondaryTags = $tags->where('attributes.isChild', false)->where('attributes.position', '===', null)->sortBy('attributes.name');
         $defaultRoute = $this->settings->get('default_route');
 
         $document->content = $this->view->make('tags::frontend.content.tags', compact('primaryTags', 'secondaryTags', 'childTags'));

--- a/src/Content/Tags.php
+++ b/src/Content/Tags.php
@@ -65,9 +65,12 @@ class Tags
     public function __invoke(Document $document, Request $request)
     {
         $tags = collect($document->payload['resources'])->where('type', 'tags');
+        $childTags = $tags->where('attributes.isChild', true);
+        $primaryTags = $tags->where('attributes.isChild', false)->where('attributes.position', '!==', NULL)->sortBy('attributes.position');
+        $secondaryTags = $tags->where('attributes.isChild', false)->where('attributes.position', '===', NULL)->sortBy('attributes.name');
         $defaultRoute = $this->settings->get('default_route');
 
-        $document->content = $this->view->make('tags::frontend.content.tags', compact('tags'));
+        $document->content = $this->view->make('tags::frontend.content.tags', compact('primaryTags', 'secondaryTags', 'childTags'));
         $document->canonicalUrl = $defaultRoute === '/tags' ? $this->url->to('forum')->base() : $request->getUri()->withQuery('');
 
         return $document;

--- a/src/Content/Tags.php
+++ b/src/Content/Tags.php
@@ -1,0 +1,56 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * (c) Toby Zerner <toby.zerner@gmail.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Flarum\Tags\Content;
+
+use Flarum\Api\Client;
+use Flarum\Frontend\Document;
+use Flarum\Tags\TagRepository;
+use Illuminate\Contracts\View\Factory;
+use Psr\Http\Message\ServerRequestInterface as Request;
+
+class Tags
+{
+    /**
+     * @var Client
+     */
+    protected $api;
+
+    /**
+     * @var Factory
+     */
+    protected $view;
+
+    /**
+     * @var TagRepository
+     */
+    protected $tags;
+
+    /**
+     * @param Client $api
+     * @param Factory $view
+     */
+    public function __construct(Client $api, Factory $view, TagRepository $tags)
+    {
+        $this->api = $api;
+        $this->view = $view;
+        $this->tags = $tags;
+    }
+
+    public function __invoke(Document $document, Request $request)
+    {
+        $tags = collect($document->payload['resources'])->where('type', 'tags');
+
+        $document->content = $this->view->make('tags::frontend.content.tags', compact('tags'));
+
+        return $document;
+    }
+}

--- a/views/frontend/content/tag.blade.php
+++ b/views/frontend/content/tag.blade.php
@@ -1,0 +1,26 @@
+@inject('url', 'Flarum\Http\UrlGenerator')
+
+<div class="container">
+    <h2>{{ $tag->name }}</h2>
+    <p>{{ $tag->description }}</p>
+
+    <ul>
+        @foreach ($apiDocument->data as $discussion)
+            <li>
+                <a href="{{ $url->to('forum')->route('discussion', [
+                    'id' => $discussion->id . (trim($discussion->attributes->slug) ? '-' . $discussion->attributes->slug : '')
+                ]) }}">
+                    {{ $discussion->attributes->title }}
+                </a>
+            </li>
+        @endforeach
+    </ul>
+
+    @if (isset($apiDocument->links->prev))
+        <a href="{{ $url->to('forum')->route('tag', ['slug' => $tag->slug]) }}?page={{ $page - 1 }}">&laquo; {{ $translator->trans('core.views.index.previous_page_button') }}</a>
+    @endif
+
+    @if (isset($apiDocument->links->next))
+        <a href="{{ $url->to('forum')->route('tag', ['slug' => $tag->slug]) }}?page={{ $page + 1 }}">{{ $translator->trans('core.views.index.next_page_button') }} &raquo;</a>
+    @endif
+</div>

--- a/views/frontend/content/tags.blade.php
+++ b/views/frontend/content/tags.blade.php
@@ -1,0 +1,38 @@
+@inject('url', 'Flarum\Http\UrlGenerator')
+
+<div class="container">
+    <h2>{{ $translator->trans('flarum-tags.forum.index.tags_link') }}</h2>
+
+    @php($primaryTags = $tags->where('attributes.isChild', false)->where('attributes.position', '!==', NULL)->sortBy('attributes.position'))
+    @php($secondaryTags = $tags->where('attributes.isChild', false)->where('attributes.position', '===', NULL)->sortBy('attributes.name'))
+
+    @foreach (array($primaryTags, $secondaryTags) as $category)
+        <ul>
+            @foreach ($category->pluck('attributes', 'id') as $id => $tag)
+                <li>
+                    <a href="{{ $url->to('forum')->route('tag', [
+                                'slug' => $tag['slug']
+                            ]) }}">
+                        {{ $tag['name'] }}
+                    </a>
+
+                    @php($children = $tags->where('attributes.isChild', true)->where('relationships.parent.data.id', $id))
+
+                    @if (!$children->isEmpty())
+                        <ul>
+                            @foreach ($children->sortBy('attributes.position')->pluck('attributes') as $child)
+                                <li>
+                                    <a href="{{ $url->to('forum')->route('tag', [
+                                                'slug' => $child['slug']
+                                            ]) }}">
+                                        {{ $child['name'] }}
+                                    </a>
+                                </li>
+                            @endforeach
+                        </ul>
+                    @endif
+                </li>
+            @endforeach
+            </ul>
+    @endforeach
+</div>

--- a/views/frontend/content/tags.blade.php
+++ b/views/frontend/content/tags.blade.php
@@ -3,10 +3,7 @@
 <div class="container">
     <h2>{{ $translator->trans('flarum-tags.forum.index.tags_link') }}</h2>
 
-    @php($primaryTags = $tags->where('attributes.isChild', false)->where('attributes.position', '!==', NULL)->sortBy('attributes.position'))
-    @php($secondaryTags = $tags->where('attributes.isChild', false)->where('attributes.position', '===', NULL)->sortBy('attributes.name'))
-
-    @foreach (array($primaryTags, $secondaryTags) as $category)
+    @foreach ([$primaryTags, $secondaryTags] as $category)
         <ul>
             @foreach ($category->pluck('attributes', 'id') as $id => $tag)
                 <li>
@@ -16,7 +13,7 @@
                         {{ $tag['name'] }}
                     </a>
 
-                    @php($children = $tags->where('attributes.isChild', true)->where('relationships.parent.data.id', $id))
+                    @php($children = $childTags->where('relationships.parent.data.id', $id))
 
                     @if (!$children->isEmpty())
                         <ul>

--- a/views/frontend/content/tags.blade.php
+++ b/views/frontend/content/tags.blade.php
@@ -13,11 +13,9 @@
                         {{ $tag['name'] }}
                     </a>
 
-                    @php($children = $childTags->where('relationships.parent.data.id', $id))
-
-                    @if (!$children->isEmpty())
+                    @if ($children->has($id))
                         <ul>
-                            @foreach ($children->sortBy('attributes.position')->pluck('attributes') as $child)
+                            @foreach ($children->get($id) as $child)
                                 <li>
                                     <a href="{{ $url->to('forum')->route('tag', [
                                                 'slug' => $child['slug']


### PR DESCRIPTION
**Refs flarum/core#1820** (pt 3)
**Fixes flarum/core#1134**

- Uses already-loaded tags from `resources` payload for tags list
    - No extra queries to database
    - Tags are always loaded and added to the forum
    - Permissions already handled
- Canonical URL

<details>
<summary>Screenshots</summary>

<img src="https://user-images.githubusercontent.com/6401250/62010189-8ab4d280-b135-11e9-846d-6f815d258415.png" width="300" />
<img src="https://user-images.githubusercontent.com/6401250/62010194-9bfddf00-b135-11e9-8856-2d6432a60bf4.png" width="300" />
<img src="https://user-images.githubusercontent.com/6401250/62010190-930d0d80-b135-11e9-8cf2-2a1840be794c.png" width="300" />
</details>