### PR TITLE
prevent lingering permissions when unrestricting

### DIFF
--- a/src/Command/EditTagHandler.php
+++ b/src/Command/EditTagHandler.php
@@ -9,7 +9,6 @@
 
 namespace Flarum\Tags\Command;
 
-use Flarum\Group\Permission;
 use Flarum\Tags\Event\TagWillBeSaved;
 use Flarum\Tags\TagRepository;
 use Flarum\Tags\TagValidator;
@@ -88,7 +87,7 @@ class EditTagHandler
         $this->validator->assertValid($tag->getDirty());
 
         if ($tag->isDirty('is_restricted') && ! $tag->is_restricted) {
-            Permission::where('permission', 'like', 'tag'.$tag->id.'.%')->delete();
+            $tag->deletePermissions();
         }
 
         $tag->save();

--- a/src/Command/EditTagHandler.php
+++ b/src/Command/EditTagHandler.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Tags\Command;
 
+use Flarum\Group\Permission;
 use Flarum\Tags\Event\TagWillBeSaved;
 use Flarum\Tags\TagRepository;
 use Flarum\Tags\TagValidator;
@@ -85,6 +86,10 @@ class EditTagHandler
         event(new TagWillBeSaved($tag, $actor, $data));
 
         $this->validator->assertValid($tag->getDirty());
+
+        if ($tag->isDirty('is_restricted') && ! $tag->is_restricted) {
+            Permission::where('permission', 'like', 'tag'.$tag->id.'.%')->delete();
+        }
 
         $tag->save();
 

--- a/src/Command/EditTagHandler.php
+++ b/src/Command/EditTagHandler.php
@@ -86,10 +86,6 @@ class EditTagHandler
 
         $this->validator->assertValid($tag->getDirty());
 
-        if ($tag->isDirty('is_restricted') && ! $tag->is_restricted) {
-            $tag->deletePermissions();
-        }
-
         $tag->save();
 
         return $tag;

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -52,8 +52,8 @@ class Tag extends AbstractModel
     {
         parent::boot();
 
-        static::deleted(function ($tag) {
-            Permission::where('permission', 'like', "tag{$tag->id}.%")->delete();
+        static::deleted(function (Tag $tag) {
+            $tag->deletePermissions();
         });
     }
 
@@ -162,6 +162,14 @@ class Tag extends AbstractModel
                 $query->where('user_id', $user->id);
             }
         ]);
+    }
+
+    /**
+     * Delete all permissions belonging to this tag.
+     */
+    public function deletePermissions()
+    {
+        Permission::where('permission', 'like', "tag{$this->id}.%")->delete();
     }
 
     protected static function getIdsWherePermission(User $user, string $permission, bool $condition = true): array

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -52,7 +52,13 @@ class Tag extends AbstractModel
     {
         parent::boot();
 
-        static::deleted(function (Tag $tag) {
+        static::saved(function (self $tag) {
+            if ($tag->wasUnrestricted()) {
+                $tag->deletePermissions();
+            }
+        });
+
+        static::deleted(function (self $tag) {
             $tag->deletePermissions();
         });
     }
@@ -162,6 +168,16 @@ class Tag extends AbstractModel
                 $query->where('user_id', $user->id);
             }
         ]);
+    }
+
+    /**
+     * Has this tag been unrestricted recently?
+     *
+     * @return bool
+     */
+    public function wasUnrestricted()
+    {
+        return ! $this->is_restricted && $this->wasChanged('is_restricted');
     }
 
     /**


### PR DESCRIPTION
Whenever a tag is no longer being restricted, a permission entry in group_permission lingers around for `viewDiscussions`. This PR removes all permissions configured after you stop restricting them.