### PR TITLE
Fix tag event posts with deleted tags erroring

### DIFF
--- a/js/src/common/helpers/tagLabel.js
+++ b/js/src/common/helpers/tagLabel.js
@@ -6,7 +6,7 @@ export default function tagLabel(tag, attrs = {}) {
   attrs.className = 'TagLabel ' + (attrs.className || '');
 
   const link = extract(attrs, 'link');
-  let tagText = tag ? tag.name() : app.translator.trans('flarum-tags.lib.deleted_tag_text');
+  const tagText = tag ? tag.name() : app.translator.trans('flarum-tags.lib.deleted_tag_text');
 
   if (tag) {
     const color = tag.color();
@@ -23,10 +23,11 @@ export default function tagLabel(tag, attrs = {}) {
   } else {
     attrs.className += ' untagged';
   }
+
   return (
     m((link ? 'a' : 'span'), attrs,
       <span className="TagLabel-text">
-        {tag.icon() && tagIcon(tag, {}, {useColor: false})} {tagText}
+        {tag && tag.icon() && tagIcon(tag, {}, {useColor: false})} {tagText}
       </span>
     )
   );


### PR DESCRIPTION
**Fixes flarum/core#1864**

I just added a check for the tag existing before showing the icon. Looks like a regression from when we added tag icons.

Also changed the `tagText` to a const... it's never changed 🤷‍♂.