### PR TITLE
Allow extensions to place items between tags link and tags list

### DIFF
--- a/js/src/forum/addTagList.js
+++ b/js/src/forum/addTagList.js
@@ -32,7 +32,7 @@ export default function() {
         active = currentTag.parent() === tag;
       }
 
-      items.add('tag' + tag.id(), TagLinkButton.component({tag, params, active}), -12);
+      items.add('tag' + tag.id(), TagLinkButton.component({tag, params, active}), -14);
     };
 
     sortTags(tags)
@@ -49,7 +49,7 @@ export default function() {
       items.add('moreTags', LinkButton.component({
         children: app.translator.trans('flarum-tags.forum.index.more_link'),
         href: app.route('tags')
-      }), -12);
+      }), -16);
     }
   });
 }

--- a/js/src/forum/addTagList.js
+++ b/js/src/forum/addTagList.js
@@ -19,7 +19,7 @@ export default function() {
 
     if (app.current instanceof TagsPage) return;
 
-    items.add('separator', Separator.component(), -10);
+    items.add('separator', Separator.component(), -12);
 
     const params = this.stickyParams();
     const tags = app.store.all('tags');
@@ -32,7 +32,7 @@ export default function() {
         active = currentTag.parent() === tag;
       }
 
-      items.add('tag' + tag.id(), TagLinkButton.component({tag, params, active}), -10);
+      items.add('tag' + tag.id(), TagLinkButton.component({tag, params, active}), -12);
     };
 
     sortTags(tags)
@@ -49,7 +49,7 @@ export default function() {
       items.add('moreTags', LinkButton.component({
         children: app.translator.trans('flarum-tags.forum.index.more_link'),
         href: app.route('tags')
-      }), -10);
+      }), -12);
     }
   });
 }


### PR DESCRIPTION
This PR sets the priority of the tags list to -12, to allow placing a menu link on -11 between the link and the list.

Issue here: https://github.com/flarum/core/issues/1923