### PR TITLE
Change Zend to Laminas

### DIFF
--- a/src/Api/Controller/OrderTagsController.php
+++ b/src/Api/Controller/OrderTagsController.php
@@ -11,10 +11,10 @@ namespace Flarum\Tags\Api\Controller;
 
 use Flarum\Tags\Tag;
 use Flarum\User\AssertPermissionTrait;
+use Laminas\Diactoros\Response\EmptyResponse;
 use Psr\Http\Message\ResponseInterface;
 use Psr\Http\Message\ServerRequestInterface;
 use Psr\Http\Server\RequestHandlerInterface;
-use Zend\Diactoros\Response\EmptyResponse;
 
 class OrderTagsController implements RequestHandlerInterface
 {


### PR DESCRIPTION
This updates the Zend namespace to Laminas for the beta.12 release of the core