### PR TITLE
fix: icon aligment for tag icons

### DIFF
--- a/js/src/common/helpers/tagIcon.js
+++ b/js/src/common/helpers/tagIcon.js
@@ -2,7 +2,7 @@ export default function tagIcon(tag, attrs = {}, settings = {}) {
   const hasIcon = tag && tag.icon();
   const { useColor = true } = settings;
 
-  attrs.className = hasIcon ? 'icon ' + tag.icon() + ' ' + (attrs.className || '') : 'icon TagIcon ' + (attrs.className || '');
+  attrs.className = 'icon TagIcon '+ (attrs.className || '') + ' ' + (hasIcon ? tag.icon() : 'default');
 
   if (tag) {
     attrs.style = attrs.style || {};

--- a/less/common/TagIcon.less
+++ b/less/common/TagIcon.less
@@ -1,14 +1,19 @@
 .TagIcon {
-  border-radius: @border-radius;
   width: 16px;
   height: 16px;
   display: inline-block;
-  vertical-align: -3px;
   margin-left: 1px;
-  background: @control-bg;
+  text-align: center;
+  font-size: 1rem;
 
   &.untagged {
     border: 1px dotted @muted-color;
     background: transparent;
+  }
+
+  &.default {
+    border-radius: @border-radius;
+    background: @control-bg;
+    vertical-align: -3px;
   }
 }


### PR DESCRIPTION
**Changes proposed in this pull request:**
The alignment of the Font Awesome icons in the tag selection modal is all over the place (and it also affects the alignment of the "Tag name" and "Tag description" rows in the same modal. However, the Icon alignment in the Admin section "Tags" is fine. So I tried to make them look the same in both places.

**Screenshot**
Before:
<img width="699" alt="Screenshot 2020-02-13 12 19 42" src="https://user-images.githubusercontent.com/4677417/74429663-ab3b4480-4e5b-11ea-9ca4-403eb99e187e.png">

After:
<img width="699" alt="Screenshot 2020-02-13 12 20 35" src="https://user-images.githubusercontent.com/4677417/74429672-b0988f00-4e5b-11ea-8896-37c6363bfb73.png">
