### PR TITLE
Performance improvements

### DIFF
--- a/src/Access/DiscussionPolicy.php
+++ b/src/Access/DiscussionPolicy.php
@@ -76,11 +76,10 @@ class DiscussionPolicy extends AbstractPolicy
     public function find(User $actor, Builder $query)
     {
         // Hide discussions which have tags that the user is not allowed to see.
-        $query->whereNotExists(function ($query) use ($actor) {
-            return $query->selectRaw('1')
+        $query->whereNotIn('discussions.id', function ($query) use ($actor) {
+            return $query->select('discussion_id')
                 ->from('discussion_tag')
-                ->whereIn('tag_id', Tag::getIdsWhereCannot($actor, 'viewDiscussions'))
-                ->whereColumn('discussions.id', 'discussion_id');
+                ->whereIn('tag_id', Tag::getIdsWhereCannot($actor, 'viewDiscussions'));
         });
 
         // Hide discussions with no tags if the user doesn't have that global
@@ -100,11 +99,10 @@ class DiscussionPolicy extends AbstractPolicy
         // If a discussion requires a certain permission in order for it to be
         // visible, then we can check if the user has been granted that
         // permission for any of the discussion's tags.
-        $query->whereExists(function ($query) use ($actor, $ability) {
-            return $query->selectRaw('1')
+        $query->whereIn('discussions.id', function ($query) use ($actor, $ability) {
+            return $query->select('discussion.id')
                 ->from('discussion_tag')
-                ->whereIn('tag_id', Tag::getIdsWhereCan($actor, 'discussion.'.$ability))
-                ->whereColumn('discussions.id', 'discussion_id');
+                ->whereIn('tag_id', Tag::getIdsWhereCan($actor, 'discussion.'.$ability));
         });
     }
 

--- a/src/Access/DiscussionPolicy.php
+++ b/src/Access/DiscussionPolicy.php
@@ -100,7 +100,7 @@ class DiscussionPolicy extends AbstractPolicy
         // visible, then we can check if the user has been granted that
         // permission for any of the discussion's tags.
         $query->whereIn('discussions.id', function ($query) use ($actor, $ability) {
-            return $query->select('discussion.id')
+            return $query->select('discussion_id')
                 ->from('discussion_tag')
                 ->whereIn('tag_id', Tag::getIdsWhereCan($actor, 'discussion.'.$ability));
         });

--- a/src/Gambit/TagGambit.php
+++ b/src/Gambit/TagGambit.php
@@ -46,7 +46,7 @@ class TagGambit extends AbstractRegexGambit
                     $query->orWhereIn('discussions.id', function ($query) {
                         $query->select('discussion_id')
                             ->from('discussion_tag');
-                    }, !$negate);
+                    }, ! $negate);
                 } else {
                     $id = $this->tags->getIdForSlug($slug);
 

--- a/src/Gambit/TagGambit.php
+++ b/src/Gambit/TagGambit.php
@@ -50,7 +50,7 @@ class TagGambit extends AbstractRegexGambit
             ->join('tags', 'tag_user.tag_id', '=', 'tags.id')
             ->where('tag_user.user_id', '=', $userId)
             ->where('tag_user.subscription', 'hide')
-            ->whereNotNull("tags.parent_id");
+            ->whereNotNull('tags.parent_id');
 
         if ($excludeTags !== null) {
             $query->whereNotIn('tags.slug', $excludeTags);

--- a/src/Listener/FilterDiscussionListByTags.php
+++ b/src/Listener/FilterDiscussionListByTags.php
@@ -45,11 +45,10 @@ class FilterDiscussionListByTags
             return;
         }
 
-        $query->whereNotExists(function ($query) {
-            return $query->selectRaw('1')
+        $query->whereNotIn('discussions.id', function ($query) {
+            return $query->select('discussion_id')
                 ->from('discussion_tag')
-                ->whereIn('tag_id', Tag::where('is_hidden', 1)->pluck('id'))
-                ->whereColumn('discussions.id', 'discussion_id');
+                ->whereIn('tag_id', Tag::where('is_hidden', 1)->pluck('id'));
         });
     }
 }


### PR DESCRIPTION
Combined effort from several members of the @giffgaff team, contributing our efforts back here.

Generally, replacing `whereExists/whereNotExists` with `whereIn/whereNotIn`