### PR TITLE
Fix alignments and checked colors in TagDiscussionModal

### DIFF
--- a/js/src/common/helpers/tagIcon.js
+++ b/js/src/common/helpers/tagIcon.js
@@ -1,8 +1,14 @@
+import classList from 'flarum/utils/classList';
+
 export default function tagIcon(tag, attrs = {}, settings = {}) {
   const hasIcon = tag && tag.icon();
   const { useColor = true } = settings;
 
-  attrs.className = 'icon TagIcon '+ (attrs.className || '') + ' ' + (hasIcon ? tag.icon() : 'default');
+  attrs.className = classList([
+    attrs.className,
+    'icon',
+    hasIcon ? tag.icon() : 'TagIcon'
+  ]);
 
   if (tag) {
     attrs.style = attrs.style || {};

--- a/less/common/TagIcon.less
+++ b/less/common/TagIcon.less
@@ -1,19 +1,14 @@
 .TagIcon {
+  border-radius: @border-radius;
   width: 16px;
   height: 16px;
   display: inline-block;
+  vertical-align: -3px;
   margin-left: 1px;
-  text-align: center;
-  font-size: 1rem;
+  background: @control-bg;
 
   &.untagged {
     border: 1px dotted @muted-color;
     background: transparent;
-  }
-
-  &.default {
-    border-radius: @border-radius;
-    background: @control-bg;
-    vertical-align: -3px;
   }
 }

--- a/less/forum/TagDiscussionModal.less
+++ b/less/forum/TagDiscussionModal.less
@@ -107,15 +107,24 @@
     &.active {
       background: @control-bg;
     }
+
+    .icon::before {
+      display: inline-block;
+      width: 16px;
+      text-align: center;
+      vertical-align: middle;
+    }
+
     &.selected {
       .icon::before {
         .fa();
         content: @fa-var-check !important;
-        color: @muted-color !important;
+        color: @muted-color;
         font-size: 14px;
-        width: 100%;
         text-align: center;
+        vertical-align: 1px;
       }
+
       &.colored .TagIcon:before {
         color: #fff;
       }
@@ -123,6 +132,7 @@
     .TagIcon {
       vertical-align: top;
       margin-top: 3px;
+      margin-left: 0;
     }
   }
 }


### PR DESCRIPTION
- Fix issues with #73 having styles apply to too many things
  - Reverted `tagIcon` code, except now it uses `classList` helper for better readability
- Fix regression from #68 with checkmark color not being overriden to white
  - Not sure why there was an `!important` for the checkmark color
- Moved alignment code to `TagDiscussionModal.less`

Screenshots:
![image](https://user-images.githubusercontent.com/6401250/75299406-f57cd800-5802-11ea-86b7-db6670f5a6d1.png)
