### PR TITLE
Fix Last Posted Discussion, Improve DiscussionCount

### DIFF
--- a/src/Listener/UpdateTagMetadata.php
+++ b/src/Listener/UpdateTagMetadata.php
@@ -20,6 +20,7 @@ use Flarum\Post\Event\Restored as PostRestored;
 use Flarum\Tags\Event\DiscussionWasTagged;
 use Flarum\Tags\Tag;
 use Illuminate\Contracts\Events\Dispatcher;
+use Illuminate\Support\Arr;
 
 class UpdateTagMetadata
 {
@@ -53,7 +54,7 @@ class UpdateTagMetadata
      */
     public function whenDiscussionWasTagged(DiscussionWasTagged $event)
     {
-        $oldTags = Tag::whereIn('id', array_pluck($event->oldTags, 'id'));
+        $oldTags = Tag::whereIn('id', array_pluck($event->oldTags, 'id'))->get();
 
         $this->updateTags($event->discussion, -1, $oldTags);
         $this->updateTags($event->discussion, 1);

--- a/src/Listener/UpdateTagMetadata.php
+++ b/src/Listener/UpdateTagMetadata.php
@@ -140,7 +140,7 @@ class UpdateTagMetadata
 
             // If this is a new / restored discussion, it isn't private, it isn't null,
             // and it's more recent than what we have now, set it as last posted discussion.
-            if ($delta >= 0 && ! $discussion->is_private && $discussion->hidden_at == null && ($discussion->last_posted_at > $tag->last_posted_at)) {
+            if ($delta >= 0 && ! $discussion->is_private && $discussion->hidden_at == null && ($discussion->last_posted_at >= $tag->last_posted_at)) {
                 $tag->setLastPostedDiscussion($discussion);
             } elseif ($discussion->id == $tag->last_posted_discussion_id) {
                 // This discussion is currently the last posted discussion, but since it didn't qualify for the above check,

--- a/src/Listener/UpdateTagMetadata.php
+++ b/src/Listener/UpdateTagMetadata.php
@@ -9,6 +9,7 @@
 
 namespace Flarum\Tags\Listener;
 
+use Flarum\Discussion\Discussion;
 use Flarum\Discussion\Event\Deleted;
 use Flarum\Discussion\Event\Hidden;
 use Flarum\Discussion\Event\Restored;
@@ -123,12 +124,8 @@ class UpdateTagMetadata
      * @param Tag[]|null $tags
      * @param Post $post: This is only used when a post has been hidden
      */
-    protected function updateTags($discussion, $delta = 0, $tags = null, $post = null)
+    protected function updateTags(Discussion $discussion, $delta = 0, $tags = null, $post = null)
     {
-        if (! $discussion) {
-            return;
-        }
-
         if (! $tags) {
             $tags = $discussion->tags;
         }

--- a/src/Listener/UpdateTagMetadata.php
+++ b/src/Listener/UpdateTagMetadata.php
@@ -20,7 +20,6 @@ use Flarum\Post\Event\Restored as PostRestored;
 use Flarum\Tags\Event\DiscussionWasTagged;
 use Flarum\Tags\Tag;
 use Illuminate\Contracts\Events\Dispatcher;
-use Illuminate\Support\Arr;
 
 class UpdateTagMetadata
 {
@@ -86,7 +85,6 @@ class UpdateTagMetadata
         $this->updateTags($event->discussion, 1);
     }
 
-
     /**
      * @param Posted $event
      */
@@ -136,11 +134,11 @@ class UpdateTagMetadata
 
         foreach ($tags as $tag) {
             // We do not count private discussions or hidden discussions in tags
-            if (!$discussion->is_private) {
+            if (! $discussion->is_private) {
                 $tag->discussion_count += $delta;
             }
 
-            if ($delta >= 0 && !$discussion->is_private && $discussion->hidden_at == null && ($discussion->last_posted_at > $tag->last_posted_at)) {
+            if ($delta >= 0 && ! $discussion->is_private && $discussion->hidden_at == null && ($discussion->last_posted_at > $tag->last_posted_at)) {
                 $tag->setLastPostedDiscussion($discussion);
             } elseif ($discussion->id == $tag->last_posted_discussion_id) {
                 $tag->refreshLastPostedDiscussion([$discussion->id]);

--- a/src/Listener/UpdateTagMetadata.php
+++ b/src/Listener/UpdateTagMetadata.php
@@ -147,7 +147,7 @@ class UpdateTagMetadata
             if ($delta >= 0 && ! $discussion->is_private && $discussion->hidden_at == null && ($discussion->last_posted_at >= $tag->last_posted_at)) {
                 $tag->setLastPostedDiscussion($discussion);
             } elseif ($discussion->id == $tag->last_posted_discussion_id) {
-                // This is to persist the refresh made in line 136. It is here instead of there so that
+                // This is to persist refreshLastPost above. It is here instead of there so that
                 // if it's not necessary, we save a DB query.
                 if ($post) {
                     $discussion->save();

--- a/src/Listener/UpdateTagMetadata.php
+++ b/src/Listener/UpdateTagMetadata.php
@@ -138,9 +138,14 @@ class UpdateTagMetadata
                 $tag->discussion_count += $delta;
             }
 
+            // If this is a new / restored discussion, it isn't private, it isn't null,
+            // and it's more recent than what we have now, set it as last posted discussion.
             if ($delta >= 0 && ! $discussion->is_private && $discussion->hidden_at == null && ($discussion->last_posted_at > $tag->last_posted_at)) {
                 $tag->setLastPostedDiscussion($discussion);
             } elseif ($discussion->id == $tag->last_posted_discussion_id) {
+                // This discussion is currently the last posted discussion, but since it didn't qualify for the above check,
+                // it should not be the last posted discussion. Therefore, we should refresh the last posted discussion,
+                // but make sure this discussion is not set so by accident, hence, we blacklist it.
                 $tag->refreshLastPostedDiscussion([$discussion->id]);
             }
 

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -121,9 +121,9 @@ class Tag extends AbstractModel
 
     public function setLastPostedDiscussion(Discussion $discussion = null)
     {
-        $this->last_posted_at = $discussion ? $discussion->last_posted_at : null;
-        $this->last_posted_discussion_id = $discussion ? $discussion->id : null;
-        $this->last_posted_user_id = $discussion ? $discussion->last_posted_user_id : null;
+        $this->last_posted_at = optional($discussion)->last_posted_at;
+        $this->last_posted_discussion_id = optional($discussion)->id;
+        $this->last_posted_user_id = optional($discussion)->last_posted_user_id;
 
         return $this;
     }

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -108,9 +108,9 @@ class Tag extends AbstractModel
         return $this->belongsToMany(Discussion::class);
     }
 
-    public function refreshLastPostedDiscussion($blacklistedIds = [])
+    public function refreshLastPostedDiscussion()
     {
-        if ($lastPostedDiscussion = $this->discussions()->where('is_private', false)->whereNull('hidden_at')->whereNotIn('id', $blacklistedIds)->latest('last_posted_at')->first()) {
+        if ($lastPostedDiscussion = $this->discussions()->where('is_private', false)->whereNull('hidden_at')->latest('last_posted_at')->first()) {
             $this->setLastPostedDiscussion($lastPostedDiscussion);
         } else {
             $this->setLastPostedDiscussion(null);

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -110,7 +110,7 @@ class Tag extends AbstractModel
 
     public function refreshLastPostedDiscussion()
     {
-        if ($lastPostedDiscussion = $this->discussions()->latest('last_posted_at')->first()) {
+        if ($lastPostedDiscussion = $this->discussions()->where('is_private', false)->where('hidden_at', null)->latest('last_posted_at')->first()) {
             $this->setLastPostedDiscussion($lastPostedDiscussion);
         }
 

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -110,7 +110,7 @@ class Tag extends AbstractModel
 
     public function refreshLastPostedDiscussion($blacklistedIds = [])
     {
-        if ($lastPostedDiscussion = $this->discussions()->where('is_private', false)->where('hidden_at', null)->whereNotIn('id', $blacklistedIds)->latest('last_posted_at')->first()) {
+        if ($lastPostedDiscussion = $this->discussions()->where('is_private', false)->whereNull('hidden_at')->whereNotIn('id', $blacklistedIds)->latest('last_posted_at')->first()) {
             $this->setLastPostedDiscussion($lastPostedDiscussion);
         } else {
             $this->setLastPostedDiscussion(null);

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -108,20 +108,22 @@ class Tag extends AbstractModel
         return $this->belongsToMany(Discussion::class);
     }
 
-    public function refreshLastPostedDiscussion()
+    public function refreshLastPostedDiscussion($blacklistedIds = [])
     {
-        if ($lastPostedDiscussion = $this->discussions()->where('is_private', false)->where('hidden_at', null)->latest('last_posted_at')->first()) {
+        if ($lastPostedDiscussion = $this->discussions()->where('is_private', false)->where('hidden_at', null)->whereNotIn('id', $blacklistedIds)->latest('last_posted_at')->first()) {
             $this->setLastPostedDiscussion($lastPostedDiscussion);
+        } else {
+            $this->setLastPostedDiscussion(null);
         }
 
         return $this;
     }
 
-    public function setLastPostedDiscussion(Discussion $discussion)
+    public function setLastPostedDiscussion(Discussion $discussion = null)
     {
-        $this->last_posted_at = $discussion->last_posted_at;
-        $this->last_posted_discussion_id = $discussion->id;
-        $this->last_posted_user_id = $discussion->last_posted_user_id;
+        $this->last_posted_at = $discussion ? $discussion->last_posted_at : null;
+        $this->last_posted_discussion_id = $discussion ? $discussion->id : null;
+        $this->last_posted_user_id = $discussion ? $discussion->last_posted_user_id : null;
 
         return $this;
     }


### PR DESCRIPTION
The calculation/caching of the last posted discsussion is currently not very good. This PR adds fixes for:
- Ensuring that private and hidden discussions aren't returned
- Hiding and restoring discussions (hidden discussions shouldn't be returned)
- Editing tags on a discussion (previously the discussion wasn't removed from the old tags).

Fixes https://github.com/FriendsOfFlarum/byobu/issues/74
Fixes https://github.com/askvortsov1/flarum-categories/issues/3
Fixes https://github.com/flarum/core/issues/2022
Fixes https://github.com/flarum/core/issues/913
Fixes https://github.com/flarum/core/issues/1476