### PR TITLE
Increase Tags Visibility Scoping Extendability

### DIFF
--- a/src/Access/DiscussionPolicy.php
+++ b/src/Access/DiscussionPolicy.php
@@ -27,6 +27,11 @@ class DiscussionPolicy extends AbstractPolicy
     protected $model = Discussion::class;
 
     /**
+     * @var Dispatcher
+     */
+    protected $events;
+
+    /**
      * @var SettingsRepositoryInterface
      */
     protected $settings;

--- a/src/Access/DiscussionPolicy.php
+++ b/src/Access/DiscussionPolicy.php
@@ -56,7 +56,7 @@ class DiscussionPolicy extends AbstractPolicy
 
             foreach ($tags as $tag) {
                 if ($tag->is_restricted) {
-                    if (!$actor->hasPermission('tag'.$tag->id.'.discussion.'.$ability)) {
+                    if (! $actor->hasPermission('tag'.$tag->id.'.discussion.'.$ability)) {
                         return false;
                     }
 

--- a/src/Access/DiscussionPolicy.php
+++ b/src/Access/DiscussionPolicy.php
@@ -16,6 +16,7 @@ use Flarum\Settings\SettingsRepositoryInterface;
 use Flarum\Tags\Tag;
 use Flarum\User\AbstractPolicy;
 use Flarum\User\User;
+use Illuminate\Contracts\Events\Dispatcher;
 use Illuminate\Database\Eloquent\Builder;
 
 class DiscussionPolicy extends AbstractPolicy
@@ -31,10 +32,12 @@ class DiscussionPolicy extends AbstractPolicy
     protected $settings;
 
     /**
+     * @param Dispatcher $events
      * @param SettingsRepositoryInterface $settings
      */
-    public function __construct(SettingsRepositoryInterface $settings)
+    public function __construct(Dispatcher $events, SettingsRepositoryInterface $settings)
     {
+        $this->events = $events;
         $this->settings = $settings;
     }
 

--- a/src/Access/DiscussionPolicy.php
+++ b/src/Access/DiscussionPolicy.php
@@ -77,17 +77,19 @@ class DiscussionPolicy extends AbstractPolicy
     public function find(User $actor, Builder $query)
     {
         // Hide discussions which have tags that the user is not allowed to see, unless an extension overrides this.
-        $query
-            ->whereNotIn('discussions.id', function ($query) use ($actor) {
-                return $query->select('discussion_id')
-                    ->from('discussion_tag')
-                    ->whereIn('tag_id', Tag::getIdsWhereCannot($actor, 'viewDiscussions'));
-            })
-            ->orWhere(function ($query) use ($actor) {
-                $this->events->dispatch(
-                    new ScopeModelVisibility($query, $actor, 'viewDiscussionsInRestrictedTags')
-                );
-            });
+        $query->where(function ($query) use ($actor) {
+            $query
+                ->whereNotIn('discussions.id', function ($query) use ($actor) {
+                    return $query->select('discussion_id')
+                        ->from('discussion_tag')
+                        ->whereIn('tag_id', Tag::getIdsWhereCannot($actor, 'viewDiscussions'));
+                })
+                ->orWhere(function ($query) use ($actor) {
+                    $this->events->dispatch(
+                        new ScopeModelVisibility($query, $actor, 'viewDiscussionsInRestrictedTags')
+                    );
+                });
+        });
 
         // Hide discussions with no tags if the user doesn't have that global
         // permission.

--- a/src/Access/DiscussionPolicy.php
+++ b/src/Access/DiscussionPolicy.php
@@ -56,7 +56,7 @@ class DiscussionPolicy extends AbstractPolicy
 
             foreach ($tags as $tag) {
                 if ($tag->is_restricted) {
-                    if (!$actor->hasPermission('tag' . $tag->id . '.discussion.' . $ability)) {
+                    if (!$actor->hasPermission('tag'.$tag->id.'.discussion.'.$ability)) {
                         return false;
                     }
 
@@ -76,7 +76,7 @@ class DiscussionPolicy extends AbstractPolicy
      */
     public function find(User $actor, Builder $query)
     {
-        // Hide discussions which have tags that the user is not allowed to see.
+        // Hide discussions which have tags that the user is not allowed to see, unless an extension overrides this.
         $query
             ->whereNotIn('discussions.id', function ($query) use ($actor) {
                 return $query->select('discussion_id')
@@ -91,7 +91,7 @@ class DiscussionPolicy extends AbstractPolicy
 
         // Hide discussions with no tags if the user doesn't have that global
         // permission.
-        if (!$actor->hasPermission('viewDiscussions')) {
+        if (! $actor->hasPermission('viewDiscussions')) {
             $query->has('tags');
         }
     }
@@ -109,7 +109,7 @@ class DiscussionPolicy extends AbstractPolicy
         $query->whereIn('discussions.id', function ($query) use ($actor, $ability) {
             return $query->select('discussion_id')
                 ->from('discussion_tag')
-                ->whereIn('tag_id', Tag::getIdsWhereCan($actor, 'discussion.' . $ability));
+                ->whereIn('tag_id', Tag::getIdsWhereCan($actor, 'discussion.'.$ability));
         });
     }
 


### PR DESCRIPTION
Fixes https://github.com/flarum/core/issues/2116.

Right now, if a user doesn't have the viewDiscussions permission for a tag, they CAN NOT see discussions in the tag, and there is no ability for extensions to override this. This PR introduces a scopeModelVisibility event dispatch, which allows extensions to override this.

An example of a use case can be found here:
https://github.com/askvortsov1/flarum-help-tags/issues/1