### PR TITLE
Remove !important because it's not needed

### DIFF
--- a/less/common/TagLabel.less
+++ b/less/common/TagLabel.less
@@ -16,22 +16,22 @@
 
   &.colored {
     .TagLabel-text {
-      color: @body-bg !important;
+      color: @body-bg;
     }
   }
 
   .DiscussionHero .TagsLabel & {
     background: transparent;
-    border-radius: @border-radius !important;
+    border-radius: @border-radius;
     font-size: 14px;
 
     &.colored {
       margin-right: 5px;
-      background: @body-bg !important;
+      background: @body-bg;
       color: @muted-color;
 
       .TagLabel-text {
-        color: inherit !important;
+        color: inherit;
       }
     }
   }


### PR DESCRIPTION
Remove !important because it's not needed and additional changing force you to hack the theme with animations that does not work on all browsers.