### PR TITLE
Remove unneeded withState when loading tags

### DIFF
--- a/src/Api/Controller/ListTagsController.php
+++ b/src/Api/Controller/ListTagsController.php
@@ -57,7 +57,7 @@ class ListTagsController extends AbstractListController
         $actor = $request->getAttribute('actor');
         $include = $this->extractInclude($request);
 
-        $tags = $this->tags->whereVisibleTo($actor)->withStateFor($actor)->get();
+        $tags = $this->tags->whereVisibleTo($actor)->get();
 
         return $tags->load($include);
     }

--- a/src/Listener/AddForumTagsRelationship.php
+++ b/src/Listener/AddForumTagsRelationship.php
@@ -51,7 +51,6 @@ class AddForumTagsRelationship
         // assign the tags data to it using an event listener.
         if ($event->isController(ShowForumController::class)) {
             $event->data['tags'] = Tag::whereVisibleTo($event->actor)
-                ->withStateFor($event->actor)
                 ->with(['parent', 'lastPostedDiscussion'])
                 ->get();
         }


### PR DESCRIPTION
Part of https://github.com/flarum/core/issues/2177.

Assembling withState for tags uses at least one query per-tag, which scales up to a LOT with many tags as per testing with @luceos. If we eliminate this unneeded strain, performance is increased.