### PR TITLE
Renamed TagWillBeSaved => Saving. Deprecated the old event.

### DIFF
--- a/src/Command/EditTagHandler.php
+++ b/src/Command/EditTagHandler.php
@@ -10,6 +10,7 @@
 namespace Flarum\Tags\Command;
 
 use Flarum\Tags\Event\Saving;
+use Flarum\Tags\Event\TagWillBeSaved;
 use Flarum\Tags\TagRepository;
 use Flarum\Tags\TagValidator;
 use Flarum\User\AssertPermissionTrait;
@@ -83,6 +84,9 @@ class EditTagHandler
         }
 
         event(new Saving($tag, $actor, $data));
+
+        // Deprecated BC layer, remove in beta 15.
+        event(new TagWillBeSaved($tag, $actor, $data));
 
         $this->validator->assertValid($tag->getDirty());
 

--- a/src/Command/EditTagHandler.php
+++ b/src/Command/EditTagHandler.php
@@ -9,7 +9,7 @@
 
 namespace Flarum\Tags\Command;
 
-use Flarum\Tags\Event\TagWillBeSaved;
+use Flarum\Tags\Event\Saving;
 use Flarum\Tags\TagRepository;
 use Flarum\Tags\TagValidator;
 use Flarum\User\AssertPermissionTrait;
@@ -82,7 +82,7 @@ class EditTagHandler
             $tag->is_restricted = (bool) $attributes['isRestricted'];
         }
 
-        event(new TagWillBeSaved($tag, $actor, $data));
+        event(new Saving($tag, $actor, $data));
 
         $this->validator->assertValid($tag->getDirty());
 

--- a/src/Event/Saving.php
+++ b/src/Event/Saving.php
@@ -12,10 +12,7 @@ namespace Flarum\Tags\Event;
 use Flarum\Tags\Tag;
 use Flarum\User\User;
 
-/**
- * @deprecated beta 14, removed beta 15.
- */
-class TagWillBeSaved
+class Saving
 {
     /**
      * @var Tag


### PR DESCRIPTION
As discussed in #86, here is a PR for the Saving event that was previously named TagWillBeSaved but should be renamed to match the general convention.
Is the `@deprecated beta 14, removed beta 15.` comment that I made right @askvortsov1 ?