### PR TITLE
Remove call to undefined method handleErrors

### DIFF
--- a/js/src/admin/components/EditTagModal.js
+++ b/js/src/admin/components/EditTagModal.js
@@ -123,6 +123,8 @@ export default class EditTagModal extends Modal {
 
     this.loading = true;
 
+    // Errors aren't passed to the modal onerror handler here. 
+    // This is done for better error visibility on smaller screen heights.
     this.tag.save(this.submitData()).then(
       () => this.hide(),
       () => this.loading = false

--- a/js/src/admin/components/EditTagModal.js
+++ b/js/src/admin/components/EditTagModal.js
@@ -125,10 +125,7 @@ export default class EditTagModal extends Modal {
 
     this.tag.save(this.submitData()).then(
       () => this.hide(),
-      response => {
-        this.loading = false;
-        this.handleErrors(response);
-      }
+      () => this.loading = false
     );
   }
 


### PR DESCRIPTION
Fixes admin erorr: `Uncaught TypeError: e.handleErrors is not a function`

Modal.handleErrors has been removed 5 years ago and became Modal.onerror (commit id: `26a821e3e28df83128d7d883a98b6cea129375a8`).