### PR TITLE
Use Link component instead of route patch for tagLabel links

### DIFF
--- a/js/src/common/helpers/tagLabel.js
+++ b/js/src/common/helpers/tagLabel.js
@@ -1,4 +1,5 @@
 import extract from 'flarum/utils/extract';
+import Link from 'flarum/components/Link';
 import tagIcon from './tagIcon';
 
 export default function tagLabel(tag, attrs = {}) {
@@ -17,14 +18,14 @@ export default function tagLabel(tag, attrs = {}) {
 
     if (link) {
       attrs.title = tag.description() || '';
-      attrs.route = app.route('tag', {tags: tag.slug()});
+      attrs.href = app.route('tag', {tags: tag.slug()});
     }
   } else {
     attrs.className += ' untagged';
   }
 
   return (
-    m((link ? 'a' : 'span'), attrs,
+    m((link ? Link : 'span'), attrs,
       <span className="TagLabel-text">
         {tag && tag.icon() && tagIcon(tag, {}, {useColor: false})} {tagText}
       </span>


### PR DESCRIPTION
Use Link component instead of route patch
see: https://github.com/flarum/tags/commit/56c4c3e16624538cd0c15a0b224fb440ef82b658

- [x] tested locally