### PR TITLE
Remove unused declaration of tags property

### DIFF
--- a/js/src/forum/addTagComposer.js
+++ b/js/src/forum/addTagComposer.js
@@ -19,7 +19,6 @@ export default function () {
   });
 
   // Add tag-selection abilities to the discussion composer.
-  DiscussionComposer.prototype.tags = [];
   DiscussionComposer.prototype.chooseTags = function () {
     app.modal.show(TagDiscussionModal, {
       selectedTags: (this.composer.fields.tags || []).slice(0),


### PR DESCRIPTION
As reported by Clark.

We no longer use `this.tags` we use `this.composer.fields.tags`.

Tested.