### PR TITLE
Fix startDiscussion global permission returning true

### DIFF
--- a/src/Access/GlobalPolicy.php
+++ b/src/Access/GlobalPolicy.php
@@ -34,8 +34,8 @@ class GlobalPolicy extends AbstractPolicy
     public function can(User $actor, string $ability)
     {
         if (in_array($ability, ['viewDiscussions', 'startDiscussion'])) {
-            $enoughPrimary = count(Tag::getIdsWhereCan($actor, $ability, true, false)) >= $this->settings->get('min_primary_tags');
-            $enoughSecondary = count(Tag::getIdsWhereCan($actor, $ability, false, true)) >= $this->settings->get('min_secondary_tags');
+            $enoughPrimary = count(Tag::getIdsWhereCan($actor, $ability, true, false)) >= $this->settings->get('flarum-tags.min_primary_tags');
+            $enoughSecondary = count(Tag::getIdsWhereCan($actor, $ability, false, true)) >= $this->settings->get('flarum-tags.min_secondary_tags');
 
             if ($enoughPrimary && $enoughSecondary) {
                 return $this->allow();

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -212,7 +212,7 @@ class Tag extends AbstractModel
                 $can = $canForTag($tag->parent);
             }
 
-            $isPrimary = $tag->position === null && ! $tag->parent;
+            $isPrimary = $tag->position !== null && ! $tag->parent;
 
             if ($can === $condition && ($includePrimary && $isPrimary || $includeSecondary && ! $isPrimary)) {
                 $ids[] = $tag->id;


### PR DESCRIPTION
**Fixes flarum/core#2509**

It's a minor fix, the rest of the logic looks good. The issue itself is not serious as users are still denied access when trying to start a discussion, it just *looks* like they have permission.

~Just want to test one more thing with globally allowing only admins to start a discussion, but allowing other groups to start a discussion with a tag scope, so I'll comeback to this.~ #108

**EDIT**: `$isPrimary` was actually evaluating secondary tags.