### PR TITLE
Fix starting discussion without tags

### DIFF
--- a/src/Listener/SaveTagsToDatabase.php
+++ b/src/Listener/SaveTagsToDatabase.php
@@ -107,6 +107,10 @@ class SaveTagsToDatabase
                 }
             }
 
+            if (! $discussion->exists && $primaryCount === 0 && $secondaryCount === 0 && ! $actor->hasPermission('startDiscussion')) {
+                throw new PermissionDeniedException;
+            }
+
             $this->validateTagCount('primary', $primaryCount);
             $this->validateTagCount('secondary', $secondaryCount);
 


### PR DESCRIPTION
**Fixes flarum/core#2510**
**Fixes flarum/core#2511**

Cleans up the code to properly handle the logic for tags when starting a discussion or editing one. I'm not sure if it would be better to separate the code into a creation method and an editing method, that might duplicate some code, but be more readable.

<details>
<summary>Logic Details</summary>
<p>

## Current code logic
```
- when a tags relationship is provided:
  - when editing a discussion:
    - check for `tag` ability on the discussion
  - check `startDiscussion` permission on each tag
  - validate tag count
  - when editing a discussion:
    - check for `addTagToDiscussion` permission on each _new_ tag
    - raise `DiscussionWasTagged` event
  - sync tags relationship
- when a tags relationship is not provided and a new discussion is being started and actor doesn't have permission to `startDiscussion`
^^^ Only works if startDiscussion permission is false and a tags relationship has not been provided at all (if you provide an empty tags relationship it'll fail as well)
```

## How it should be
**Start Discussion**
```
- check ability to `startDiscussion` in each tag
- validate tag count
- sync tags relationship
```
**Edit Discussion**
```
- when a tags relationship is provided:
  - check ability to `tag` the discussion
  - check ability to `addToDiscussion` for each _new_ tag
  - validate tag count
  - raise `DiscussionWasTagged` event
  - sync tags relationship
```

## New Code Logic
```
- when a tags relationship is provided:
  - make an array of new tag models
- when editing and a tags relationship is provided:
  - check ability to `tag` discussion
  - check ability to `addToDiscussion` for each _new_ tag
  - raise `DiscussionWasTagged` event
- when starting or a tags relationship is provided:
  - when starting a discussion:
    - check ability to `startDiscussion` on each tag
  - validate tag count
  - sync tags relationship
```

</p>