### PR TITLE
Fix starting a discussion without tags, without global startDiscussion perm

### DIFF
--- a/src/Listener/SaveTagsToDatabase.php
+++ b/src/Listener/SaveTagsToDatabase.php
@@ -114,6 +114,10 @@ class SaveTagsToDatabase
                 $discussion->tags()->sync($newTagIds);
             });
         }
+
+        if ($primaryCount === 0 && $secondaryCount === 0 && ! $actor->hasPermission('startDiscussion')) {
+            throw new PermissionDeniedException;
+        }
     }
 
     /**

--- a/src/Listener/SaveTagsToDatabase.php
+++ b/src/Listener/SaveTagsToDatabase.php
@@ -115,7 +115,7 @@ class SaveTagsToDatabase
             });
         }
 
-        if ($primaryCount === 0 && $secondaryCount === 0 && ! $actor->hasPermission('startDiscussion')) {
+        if (! $discussion->exists && $primaryCount === 0 && $secondaryCount === 0 && ! $actor->hasPermission('startDiscussion')) {
             throw new PermissionDeniedException;
         }
     }


### PR DESCRIPTION
**Fixes flarum/core#2511**

It's a special case scenario, where the user in blue role has the **ability** to `startDiscussion` (because he has enough primary and secondary tags discussion starting permissions). But does not have the **permission** to globally `startDiscussion`, so we have to explicitly check that when no tags are given and the user doesn't have the permission, we deny access.

This isn't something we can move to the policy because the policy does not know how many tags the user has provided.