### PR TITLE
Add permission to bypass tag count requirements

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -47,7 +47,10 @@ return [
         ->belongsToMany('tags', Tag::class, 'discussion_tag'),
 
     (new Extend\ApiSerializer(ForumSerializer::class))
-        ->hasMany('tags', TagSerializer::class),
+        ->hasMany('tags', TagSerializer::class)
+        ->attribute('canBypassTagCounts', function (ForumSerializer $serializer) {
+            return $serializer->getActor()->can('bypassTagCounts');
+        }),
 
     (new Extend\ApiSerializer(DiscussionSerializer::class))
         ->hasMany('tags', TagSerializer::class)

--- a/js/src/admin/addTagPermission.js
+++ b/js/src/admin/addTagPermission.js
@@ -5,5 +5,10 @@ export default function () {
       icon: 'fas fa-tag',
       label: app.translator.trans('flarum-tags.admin.permissions.tag_discussions_label'),
       permission: 'discussion.tag',
+    }, 'moderate', 95)
+    .registerPermission({
+      icon: 'fas fa-tags',
+      label: app.translator.trans('flarum-tags.admin.permissions.bypass_tag_counts_label'),
+      permission: 'bypassTagCounts',
     }, 'moderate', 95);
 }

--- a/js/src/admin/addTagPermission.js
+++ b/js/src/admin/addTagPermission.js
@@ -10,5 +10,5 @@ export default function () {
       icon: 'fas fa-tags',
       label: app.translator.trans('flarum-tags.admin.permissions.bypass_tag_counts_label'),
       permission: 'bypassTagCounts',
-    }, 'moderate', 95);
+    }, 'start', 89);
 }

--- a/js/src/forum/components/TagDiscussionModal.js
+++ b/js/src/forum/components/TagDiscussionModal.js
@@ -177,7 +177,7 @@ export default class TagDiscussionModal extends Modal {
             </div>
           </div>
           <div className="TagDiscussionModal-form-submit App-primaryControl">
-            <Button type="submit" className="Button Button--primary" disabled={primaryCount < this.minPrimary || secondaryCount < this.minSecondary} icon="fas fa-check">
+            <Button type="submit" className="Button Button--primary" disabled={!this.meetsRequirements(primaryCount, secondaryCount)} icon="fas fa-check">
               {app.translator.trans('flarum-tags.forum.choose_tags.submit_button')}
             </Button>
           </div>
@@ -216,6 +216,14 @@ export default class TagDiscussionModal extends Modal {
         </ul>
       </div>
     ];
+  }
+
+  meetsRequirements(primaryCount, secondaryCount) {
+    if (app.forum.attribute('canBypassTagCounts')) {
+      return true;
+    }
+
+    return primaryCount >= this.minPrimary && secondaryCount >= this.minSecondary;
   }
 
   toggleTag(tag) {

--- a/src/Access/GlobalPolicy.php
+++ b/src/Access/GlobalPolicy.php
@@ -34,6 +34,10 @@ class GlobalPolicy extends AbstractPolicy
     public function can(User $actor, string $ability)
     {
         if (in_array($ability, ['viewDiscussions', 'startDiscussion'])) {
+            if ($actor->hasPermission($ability) && $actor->hasPermission('bypassTagCounts')) {
+                return $this->allow();
+            }
+
             $enoughPrimary = count(Tag::getIdsWhereCan($actor, $ability, true, false)) >= $this->settings->get('min_primary_tags');
             $enoughSecondary = count(Tag::getIdsWhereCan($actor, $ability, false, true)) >= $this->settings->get('min_secondary_tags');
 

--- a/src/Listener/SaveTagsToDatabase.php
+++ b/src/Listener/SaveTagsToDatabase.php
@@ -106,7 +106,7 @@ class SaveTagsToDatabase
                     $secondaryCount++;
                 }
             }
-            
+
             if (! $discussion->exists && $primaryCount === 0 && $secondaryCount === 0 && ! $actor->hasPermission('startDiscussion')) {
                 throw new PermissionDeniedException;
             }

--- a/src/Listener/SaveTagsToDatabase.php
+++ b/src/Listener/SaveTagsToDatabase.php
@@ -86,8 +86,10 @@ class SaveTagsToDatabase
                 }
             }
 
-            $this->validateTagCount('primary', $primaryCount);
-            $this->validateTagCount('secondary', $secondaryCount);
+            if (! $actor->can('bypassTagCounts', $discussion)) {
+                $this->validateTagCount('primary', $primaryCount);
+                $this->validateTagCount('secondary', $secondaryCount);
+            }
 
             if ($discussion->exists) {
                 $oldTags = $discussion->tags()->get();


### PR DESCRIPTION
**Fixes flarum/core#2138**

Before I PR the english repo, would we rather have the permission in "Create" category named something like "Start discussion without tag count requirements" ? or in "Moderate" category with something like "Bypass minimum number of tags required" ?

You'll notice that I didn't change the behavior of the TagDiscussionModal showing up when the min requirements are not met even if you have permission. They can still submit, that way it is more explicit that they are bypassing the required amount of tags.

* [x] flarum/lang-english#182