### PR TITLE
Add missing Button-label span from ButtonLink

### DIFF
--- a/js/src/forum/components/TagLinkButton.js
+++ b/js/src/forum/components/TagLinkButton.js
@@ -20,7 +20,9 @@ export default class TagLinkButton extends LinkButton {
         style={active && tag ? {color: tag.color()} : ''}
         title={description || ''}>
         {tagIcon(tag, {className: 'Button-icon'})}
-        {tag ? tag.name() : app.translator.trans('flarum-tags.forum.index.untagged_link')}
+        <span className="Button-label">
+          {tag ? tag.name() : app.translator.trans('flarum-tags.forum.index.untagged_link')}
+        </span>
       </Link>
     );
   }


### PR DESCRIPTION
Every side nav item created by flarum/core (e.g. All Discussions, etc.) includes this span, so tags should too.