### PR TITLE
Add "TagLabel--child" class to aid with custom theming

### DIFF
--- a/js/src/common/helpers/tagLabel.js
+++ b/js/src/common/helpers/tagLabel.js
@@ -21,7 +21,9 @@ export default function tagLabel(tag, attrs = {}) {
       attrs.href = app.route('tag', {tags: tag.slug()});
     }
 
-    attrs["data-is-child"] = tag.data.attributes.isChild ? "true" : "false";
+    if (tag.data.attributes.isChild()) {
+      attrs['data-is-child'] = 'true'
+    }
   } else {
     attrs.className += ' untagged';
   }

--- a/js/src/common/helpers/tagLabel.js
+++ b/js/src/common/helpers/tagLabel.js
@@ -22,7 +22,7 @@ export default function tagLabel(tag, attrs = {}) {
     }
 
     if (tag.isChild()) {
-      attrs.className += ' TagLabel--child'
+      attrs.className += ' TagLabel--child';
     }
   } else {
     attrs.className += ' untagged';

--- a/js/src/common/helpers/tagLabel.js
+++ b/js/src/common/helpers/tagLabel.js
@@ -1,38 +1,37 @@
-import extract from "flarum/utils/extract";
-import Link from "flarum/components/Link";
-import tagIcon from "./tagIcon";
+import extract from 'flarum/utils/extract';
+import Link from 'flarum/components/Link';
+import tagIcon from './tagIcon';
 
 export default function tagLabel(tag, attrs = {}) {
   attrs.style = attrs.style || {};
-  attrs.className = "TagLabel " + (attrs.className || "");
+  attrs.className = 'TagLabel ' + (attrs.className || '');
 
-  const link = extract(attrs, "link");
-  const tagText = tag
-    ? tag.name()
-    : app.translator.trans("flarum-tags.lib.deleted_tag_text");
+  const link = extract(attrs, 'link');
+  const tagText = tag ? tag.name() : app.translator.trans('flarum-tags.lib.deleted_tag_text');
 
   if (tag) {
     const color = tag.color();
     if (color) {
       attrs.style.backgroundColor = attrs.style.color = color;
-      attrs.className += " colored";
+      attrs.className += ' colored';
     }
 
     if (link) {
-      attrs.title = tag.description() || "";
-      attrs.href = app.route("tag", { tags: tag.slug() });
+      attrs.title = tag.description() || '';
+      attrs.href = app.route('tag', {tags: tag.slug()});
     }
 
     attrs["data-is-child"] = tag.data.attributes.isChild ? "true" : "false";
+    console.log(tag);
   } else {
-    attrs.className += " untagged";
+    attrs.className += ' untagged';
   }
 
-  return m(
-    link ? Link : "span",
-    attrs,
-    <span className="TagLabel-text">
-      {tag && tag.icon() && tagIcon(tag, {}, { useColor: false })} {tagText}
-    </span>
+  return (
+    m((link ? Link : 'span'), attrs,
+      <span className="TagLabel-text">
+        {tag && tag.icon() && tagIcon(tag, {}, {useColor: false})} {tagText}
+      </span>
+    )
   );
 }

--- a/js/src/common/helpers/tagLabel.js
+++ b/js/src/common/helpers/tagLabel.js
@@ -21,7 +21,7 @@ export default function tagLabel(tag, attrs = {}) {
       attrs.href = app.route('tag', {tags: tag.slug()});
     }
     
-    attrs["data-is-secondary"] = tag.data.attributes.isChild;
+    attrs["data-is-child"] = tag.data.attributes.isChild;
   } else {
     attrs.className += ' untagged';
   }

--- a/js/src/common/helpers/tagLabel.js
+++ b/js/src/common/helpers/tagLabel.js
@@ -22,7 +22,6 @@ export default function tagLabel(tag, attrs = {}) {
     }
 
     attrs["data-is-child"] = tag.data.attributes.isChild ? "true" : "false";
-    console.log(tag);
   } else {
     attrs.className += ' untagged';
   }

--- a/js/src/common/helpers/tagLabel.js
+++ b/js/src/common/helpers/tagLabel.js
@@ -22,7 +22,7 @@ export default function tagLabel(tag, attrs = {}) {
     }
 
     if (tag.data.attributes.isChild()) {
-      attrs.className += 'TagLabel--child'
+      attrs.className += ' TagLabel--child'
     }
   } else {
     attrs.className += ' untagged';

--- a/js/src/common/helpers/tagLabel.js
+++ b/js/src/common/helpers/tagLabel.js
@@ -1,36 +1,38 @@
-import extract from 'flarum/utils/extract';
-import Link from 'flarum/components/Link';
-import tagIcon from './tagIcon';
+import extract from "flarum/utils/extract";
+import Link from "flarum/components/Link";
+import tagIcon from "./tagIcon";
 
 export default function tagLabel(tag, attrs = {}) {
   attrs.style = attrs.style || {};
-  attrs.className = 'TagLabel ' + (attrs.className || '');
+  attrs.className = "TagLabel " + (attrs.className || "");
 
-  const link = extract(attrs, 'link');
-  const tagText = tag ? tag.name() : app.translator.trans('flarum-tags.lib.deleted_tag_text');
+  const link = extract(attrs, "link");
+  const tagText = tag
+    ? tag.name()
+    : app.translator.trans("flarum-tags.lib.deleted_tag_text");
 
   if (tag) {
     const color = tag.color();
     if (color) {
       attrs.style.backgroundColor = attrs.style.color = color;
-      attrs.className += ' colored';
+      attrs.className += " colored";
     }
 
     if (link) {
-      attrs.title = tag.description() || '';
-      attrs.href = app.route('tag', {tags: tag.slug()});
+      attrs.title = tag.description() || "";
+      attrs.href = app.route("tag", { tags: tag.slug() });
     }
-    
-    attrs["data-is-child"] = tag.data.attributes.isChild;
+
+    attrs["data-is-child"] = tag.data.attributes.isChild ? "true" : "false";
   } else {
-    attrs.className += ' untagged';
+    attrs.className += " untagged";
   }
 
-  return (
-    m((link ? Link : 'span'), attrs,
-      <span className="TagLabel-text">
-        {tag && tag.icon() && tagIcon(tag, {}, {useColor: false})} {tagText}
-      </span>
-    )
+  return m(
+    link ? Link : "span",
+    attrs,
+    <span className="TagLabel-text">
+      {tag && tag.icon() && tagIcon(tag, {}, { useColor: false })} {tagText}
+    </span>
   );
 }

--- a/js/src/common/helpers/tagLabel.js
+++ b/js/src/common/helpers/tagLabel.js
@@ -20,6 +20,8 @@ export default function tagLabel(tag, attrs = {}) {
       attrs.title = tag.description() || '';
       attrs.href = app.route('tag', {tags: tag.slug()});
     }
+    
+    attrs["data-is-secondary"] = tag.data.attributes.isChild;
   } else {
     attrs.className += ' untagged';
   }

--- a/js/src/common/helpers/tagLabel.js
+++ b/js/src/common/helpers/tagLabel.js
@@ -22,7 +22,7 @@ export default function tagLabel(tag, attrs = {}) {
     }
 
     if (tag.data.attributes.isChild()) {
-      attrs['data-is-child'] = 'true'
+      attrs.className += 'TagLabel--child'
     }
   } else {
     attrs.className += ' untagged';

--- a/js/src/common/helpers/tagLabel.js
+++ b/js/src/common/helpers/tagLabel.js
@@ -21,7 +21,7 @@ export default function tagLabel(tag, attrs = {}) {
       attrs.href = app.route('tag', {tags: tag.slug()});
     }
 
-    if (tag.data.attributes.isChild()) {
+    if (tag.isChild()) {
       attrs.className += ' TagLabel--child'
     }
   } else {


### PR DESCRIPTION
I've run into issues with theming tags in discussion lists and other areas as there's nothing in the DOM that can be used to differentiate between primary/secondary/child tags.

Adding this custom data attribute would be super helpful for theming, especially with extensions like night mode where keeping the tags the same colour between light/dark could make them unreadable.

----

**PS:** The repo seems to be missing the Prettier stuff that other core repos have. Should I PR it all in?