### PR TITLE
Max-height for tags settings

### DIFF
--- a/less/admin/TagsPage.less
+++ b/less/admin/TagsPage.less
@@ -96,6 +96,7 @@ li:not(.sortable-dragging)>.TagListItem-info:hover>.Button {
 
   .Form {
     min-width: 300px;
+    max-height: 500px;
 
     >label {
       margin-bottom: 10px;


### PR DESCRIPTION
The form (3rd column) of the tags page can get super long with lots of tags as its height is related to the tags lists. This limits its height to a reasonable one. 

Core: https://github.com/flarum/core/pull/2593