### PR TITLE
Floating Discussion Title

### DIFF
--- a/js/src/common/helpers/tagLabel.js
+++ b/js/src/common/helpers/tagLabel.js
@@ -24,6 +24,10 @@ export default function tagLabel(tag, attrs = {}) {
     if (tag.isChild()) {
       attrs.className += ' TagLabel--child';
     }
+
+    if (tag.isPrimary()) {
+      attrs.className += ' TagLabel--primary';
+    }
   } else {
     attrs.className += ' untagged';
   }

--- a/less/admin/TagsPage.less
+++ b/less/admin/TagsPage.less
@@ -96,6 +96,7 @@ li:not(.sortable-dragging)>.TagListItem-info:hover>.Button {
 
   .Form {
     min-width: 300px;
+    max-height: 500px;
 
     >label {
       margin-bottom: 10px;

--- a/less/forum.less
+++ b/less/forum.less
@@ -11,6 +11,12 @@
     margin-top: 15px;
   }
 }
+.DiscussionHero--floating {
+  .TagLabel:not(.TagLabel--primary) {
+    display: none;
+  }
+}
+
 .TagLinkButton.child {
   @media @tablet-up {
     padding-top: 4px;


### PR DESCRIPTION
Hides non-primary tags in the floating hero to prevent a tags overload! Also as a bonus adds a class for theming. Editing tags still works :)

ref: https://github.com/flarum/core/pull/2606