### PR TITLE
Eager load tags relation in discussion, posts and flags listing endpoints

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -62,8 +62,12 @@ return [
             return $serializer->getActor()->can('tag', $model);
         }),
 
+    (new Extend\ApiController(FlarumController\ListPostsController::class))
+        ->load('discussion.tags'),
+
     (new Extend\ApiController(FlarumController\ListDiscussionsController::class))
-        ->addInclude(['tags', 'tags.state']),
+        ->addInclude(['tags', 'tags.state'])
+        ->load('tags'),
 
     (new Extend\ApiController(FlarumController\ShowDiscussionController::class))
         ->addInclude(['tags', 'tags.state']),

--- a/extend.php
+++ b/extend.php
@@ -15,6 +15,7 @@ use Flarum\Discussion\Event\Saving;
 use Flarum\Discussion\Filter\DiscussionFilterer;
 use Flarum\Discussion\Search\DiscussionSearcher;
 use Flarum\Extend;
+use Flarum\Flags\Api\Controller\ListFlagsController;
 use Flarum\Flags\Flag;
 use Flarum\Tags\Access;
 use Flarum\Tags\Api\Controller;
@@ -64,6 +65,9 @@ return [
 
     (new Extend\ApiController(FlarumController\ListPostsController::class))
         ->load('discussion.tags'),
+
+    (new Extend\ApiController(ListFlagsController::class))
+        ->load('post.discussion.tags'),
 
     (new Extend\ApiController(FlarumController\ListDiscussionsController::class))
         ->addInclude(['tags', 'tags.state'])


### PR DESCRIPTION
**Part of flarum/core#2637**
**Works with flarum/core#2724**

When discussions are loaded, the `tags` relationship is always needed, because the DiscussionPolicy accesses said relation.
The key difference to note here between including relationships and eager loading them, is that just because we eager load it doesn't mean it will be included in the JSON response, the response always included relationships explicitly included in the request.