### PR TITLE
Permission Tag Scoping Field

### DIFF
--- a/js/src/admin/addTagsPermissionScope.js
+++ b/js/src/admin/addTagsPermissionScope.js
@@ -30,6 +30,8 @@ export default function() {
         label: tagLabel(tag),
         onremove: () => tag.save({isRestricted: false}),
         render: item => {
+          if (item.tagScoped !== undefined) return item.tagScoped;
+          
           if (item.permission === 'viewDiscussions'
             || item.permission === 'startDiscussion'
             || (item.permission && item.permission.indexOf('discussion.') === 0)) {


### PR DESCRIPTION
Part of https://github.com/flarum/core/issues/2202

This allows tag scoping permissions that don't start with `discussion`, or on the contrary, removing tag scoping from permissions that DO start with `discussion`.