### PR TITLE
Refactor queryIdsWhereCan

### DIFF
--- a/src/Access/GlobalPolicy.php
+++ b/src/Access/GlobalPolicy.php
@@ -37,8 +37,8 @@ class GlobalPolicy extends AbstractPolicy
             if ($actor->hasPermission($ability) && $actor->hasPermission('bypassTagCounts')) {
                 return $this->allow();
             }
-            $enoughPrimary = Tag::queryIdsWhereCan(Tag::query()->getQuery(), $actor, $ability, true, false)->count() >= $this->settings->get('flarum-tags.min_primary_tags');
-            $enoughSecondary = Tag::queryIdsWhereCan(Tag::query()->getQuery(), $actor, $ability, false, true)->count() >= $this->settings->get('flarum-tags.min_secondary_tags');
+            $enoughPrimary = Tag::queryIdsWhereHasPermission($actor, $ability, null, true, false)->count() >= $this->settings->get('flarum-tags.min_primary_tags');
+            $enoughSecondary = Tag::queryIdsWhereHasPermission($actor, $ability, null, false, true)->count() >= $this->settings->get('flarum-tags.min_secondary_tags');
 
             if ($enoughPrimary && $enoughSecondary) {
                 return $this->allow();

--- a/src/Access/ScopeDiscussionVisibility.php
+++ b/src/Access/ScopeDiscussionVisibility.php
@@ -28,7 +28,7 @@ class ScopeDiscussionVisibility
                     return $query->select('discussion_id')
                         ->from('discussion_tag')
                         ->whereNotIn('tag_id', function ($query) use ($actor) {
-                            Tag::queryIdsWhereCan($query->from('tags'), $actor, 'viewDiscussions');
+                            Tag::queryIdsWhereHasPermission($actor, 'viewDiscussions', $query->from('tags'));
                         });
                 })
                 ->orWhere(function ($query) use ($actor) {

--- a/src/Access/ScopeDiscussionVisibilityForAbility.php
+++ b/src/Access/ScopeDiscussionVisibilityForAbility.php
@@ -33,7 +33,7 @@ class ScopeDiscussionVisibilityForAbility
             return $query->select('discussion_id')
                 ->from('discussion_tag')
                 ->whereIn('tag_id', function ($query) use ($actor, $ability) {
-                    Tag::queryIdsWhereCan($query->from('tags'), $actor, 'discussion.'.$ability);
+                    Tag::queryIdsWhereHasPermission($actor, 'discussion.'.$ability, $query->from('tags'));
                 });
         });
     }

--- a/src/Access/ScopeFlagVisibility.php
+++ b/src/Access/ScopeFlagVisibility.php
@@ -29,7 +29,7 @@ class ScopeFlagVisibility
                 return $query->selectRaw('1')
                     ->from('discussion_tag')
                     ->whereNotIn('tag_id', function ($query) use ($actor) {
-                        Tag::queryIdsWhereCan($query->from('tags'), $actor, 'discussion.viewFlags');
+                        Tag::queryIdsWhereHasPermission($actor, 'discussion.viewFlags', $query->from('tags'));
                     })
                     ->whereColumn('discussions.id', 'discussion_id');
             });

--- a/src/Access/ScopeTagVisibility.php
+++ b/src/Access/ScopeTagVisibility.php
@@ -22,7 +22,7 @@ class ScopeTagVisibility
     public function __invoke(User $actor, Builder $query)
     {
         $query->whereIn('id', function ($query) use ($actor) {
-            Tag::queryIdsWhereCan($query, $actor, 'viewDiscussions');
+            Tag::queryIdsWhereHasPermission($actor, 'viewDiscussions', $query);
         });
     }
 }

--- a/src/Access/TagPolicy.php
+++ b/src/Access/TagPolicy.php
@@ -15,25 +15,10 @@ use Flarum\User\User;
 
 class TagPolicy extends AbstractPolicy
 {
-    /**
-     * @param User $actor
-     * @param Tag $tag
-     * @return bool|null
-     */
-    public function startDiscussion(User $actor, Tag $tag)
+    public function can(User $actor, string $ability, Tag $tag)
     {
         if ($tag->is_restricted) {
-            return $actor->hasPermission('tag'.$tag->id.'.startDiscussion') ? $this->allow() : $this->deny();
+            return Tag::queryIdsWhereHasPermission($actor, $ability)->where('id', $tag->id)->count() !== 0;
         }
-    }
-
-    /**
-     * @param User $actor
-     * @param Tag $tag
-     * @return bool|null
-     */
-    public function addToDiscussion(User $actor, Tag $tag)
-    {
-        return $actor->can('startDiscussion', $tag) ? $this->allow() : $this->deny();
     }
 }

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -219,8 +219,12 @@ class Tag extends AbstractModel
         }
     }
 
-    public static function queryIdsWhereCan(QueryBuilder $base, User $user, string $currPermission, bool $includePrimary = true, bool $includeSecondary = true): QueryBuilder
+    public static function queryIdsWhereHasPermission(User $user, string $currPermission, QueryBuilder $base = null, bool $includePrimary = true, bool $includeSecondary = true): QueryBuilder
     {
+        if ($base == null) {
+            $base = Tag::query()->getQuery();
+        }
+
         $hasGlobalPermission = $user->hasPermission($currPermission);
         $isAdmin = $user->isAdmin();
         $allPermissions = $user->getPermissions();


### PR DESCRIPTION
- Rename to queryIdsWhereHasPermission, since that's more accurate
- Make the base query an optional 3rd argument. This feels more intuitive
- Add a `can` function in AbstractPolicy, so extensions that add tag scopable permissions don't need to define their own policies (e.g. with approval)

This makes https://github.com/flarum/approval/pull/27 obsolete.