### PR TITLE
Restore searching in tags when on tag page

### DIFF
--- a/js/src/forum/addTagFilter.js
+++ b/js/src/forum/addTagFilter.js
@@ -89,6 +89,9 @@ export default function() {
 
     if (this.params.tags) {
       params.filter.tag = this.params.tags;
+      // TODO: replace this with a more robust system.
+      const q = params.filter.q;
+      params.filter.q = q ? `${q} tag:${this.params.tags}` : '';
     }
   });
 }


### PR DESCRIPTION
This was a small tweak as a result of the search / filter split, but has resulted in multiple complaints (https://discuss.flarum.org/d/26996-tags-search/4 being the most recent). This PR restores the previour behavior for stable. In the future, we should adopt a more robust system.