### PR TITLE
Unset tags relation after setting

### DIFF
--- a/src/Listener/SaveTagsToDatabase.php
+++ b/src/Listener/SaveTagsToDatabase.php
@@ -118,6 +118,7 @@ class SaveTagsToDatabase
 
             $discussion->afterSave(function ($discussion) use ($newTagIds) {
                 $discussion->tags()->sync($newTagIds);
+                $discussion->unsetRelation('tags');
             });
         }
     }


### PR DESCRIPTION
A similar issue in groups caused https://github.com/flarum/core/issues/2866, which was an absolute pain to debug. I think we should get this fix in so it doesn't cause similarly confusing bugs.

This ensures that the proper tag values are returned to the API by clearing any cached tags before returning a response. It also makes sure that the listeners to the `DiscussionWasTagged` event won't have old data under `$event->discussion->tags`.

Fixes https://github.com/flarum/core/issues/2514