### PR TITLE
Check that `included` array exists

### DIFF
--- a/src/Content/Tag.php
+++ b/src/Content/Tag.php
@@ -82,7 +82,7 @@ class Tag
         $tagsDocument = $this->getTagsDocument($request, $slug);
 
         $apiDocument->included[] = $tagsDocument->data;
-        $includedTags = $tagsDocument->included;
+        $includedTags = $tagsDocument->included ?? [];
         foreach ((array) $includedTags as $includedTag) {
             $apiDocument->included[] = $includedTag;
         }


### PR DESCRIPTION
Secondary tag document has no array of `included` tags.