### PR TITLE
Load all tags in permission grid

### DIFF
--- a/js/src/admin/addTagsPermissionScope.js
+++ b/js/src/admin/addTagsPermissionScope.js
@@ -3,12 +3,33 @@ import PermissionGrid from 'flarum/components/PermissionGrid';
 import PermissionDropdown from 'flarum/components/PermissionDropdown';
 import Dropdown from 'flarum/components/Dropdown';
 import Button from 'flarum/components/Button';
+import LoadingIndicator from 'flarum/components/LoadingIndicator';
 
 import tagLabel from '../common/helpers/tagLabel';
 import tagIcon from '../common/helpers/tagIcon';
 import sortTags from '../common/utils/sortTags';
 
 export default function() {
+  extend(PermissionGrid.prototype, 'oninit', function () {
+    this.loading = true;
+  })
+
+  extend(PermissionGrid.prototype, 'oncreate', function () {
+    app.store.find('tags').then(() => {
+      this.loading = false;
+
+      m.redraw();
+    });
+  });
+
+  override(PermissionGrid.prototype, 'view', function (original, vnode) {
+    if (this.loading) {
+      return <LoadingIndicator />;
+    }
+
+    return original(vnode);
+  })
+
   override(app, 'getRequiredPermissions', (original, permission) => {
     const tagPrefix = permission.match(/^tag\d+\./);
 


### PR DESCRIPTION
**Fixes flarum/core#2891**

Loads all tags before rendering the grid since we now only load a subset with the forum serializer.