### PR TITLE
Fix wrong subtags listing in sidebar

### DIFF
--- a/js/src/forum/components/TagsPage.js
+++ b/js/src/forum/components/TagsPage.js
@@ -22,11 +22,11 @@ export default class TagsPage extends Page {
     if (preloaded) {
       this.tags = sortTags(preloaded.filter(tag => !tag.isChild()));
       return;
-    }    
+    }
 
     this.loading = true;
 
-    app.tagList.load(['children', 'lastPostedDiscussion']).then(() => {
+    app.tagList.load(['children', 'lastPostedDiscussion', 'parent']).then(() => {
       this.tags = sortTags(app.store.all('tags').filter(tag => !tag.isChild()));
 
       this.loading = false;


### PR DESCRIPTION
**Fixes flarum/core#2895**

The missing parent relationship in the tags page lead to the filtering of the active tag's subtags to return a wrong `true` value, the parent relationship is necessary.