### PR TITLE
resolves the issue with secondaries loading sporadically

### DIFF
--- a/js/src/forum/addTagFilter.js
+++ b/js/src/forum/addTagFilter.js
@@ -85,7 +85,7 @@ export default function() {
 
   // Translate that parameter into a gambit appended to the search query.
   extend(DiscussionListState.prototype, 'requestParams', function(params) {
-    params.include.push('tags');
+    params.include.push('tags', 'tags.parent');
 
     if (this.params.tags) {
       params.filter.tag = this.params.tags;


### PR DESCRIPTION
When starting the forum from anything but the index and you go to the index and then any other tag, all secondaries in the js store are shown. This is caused by a missing parent include when hitting the index.

This also seems to fix flarum/core#2907