### PR TITLE
Rename tag scoped viewDiscussion -> viewForum permission

### DIFF
--- a/migrations/2021_06_21_00000_rename_permissions.php
+++ b/migrations/2021_06_21_00000_rename_permissions.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of Flarum.
+ *
+ * For detailed copyright and license information, please view the
+ * LICENSE file that was distributed with this source code.
+ */
+
+use Illuminate\Database\Schema\Builder;
+
+return [
+    'up' => function (Builder $schema) {
+        $db = $schema->getConnection();
+
+        $db->table('group_permission')
+            ->where('permission', 'LIKE', 'tag%.viewDiscussions')
+            ->update(['permission' => $db->raw("REPLACE(permission,  'viewDiscussions', 'viewForum')")]);
+    },
+
+    'down' => function (Builder $schema) {
+        $db = $schema->getConnection();
+
+        $db->table('group_permission')
+            ->where('permission', 'LIKE', 'tag%.viewForum')
+            ->update(['permission' => $db->raw("REPLACE(permission,  'viewForum', 'viewDiscussions')")]);
+    }
+];


### PR DESCRIPTION
Addresses https://github.com/flarum/core/issues/2924

The rename `viewDiscussions` migration introduced for Flarum 1.0 does not take tag scoped permissions into account
https://github.com/flarum/core/blob/e92c267cdec46266b633f71c2f41040731cdaf39/migrations/2021_05_10_000000_rename_permissions.php#L17

This adds a new migration to additionally rename `tagX.viewDiscussions` to `tagX.viewForum`

Tested locally on an upgrade from core `beta.16` to `1.0.3`