### PR TITLE
Load parent relation in Tags content

### DIFF
--- a/src/Content/Tags.php
+++ b/src/Content/Tags.php
@@ -103,7 +103,7 @@ class Tags
     private function getTagsDocument(Request $request)
     {
         return json_decode($this->api->withParentRequest($request)->withQueryParams([
-            'include' => 'children,lastPostedDiscussion'
+            'include' => 'children,lastPostedDiscussion,parent'
         ])->get('/tags')->getBody(), true);
     }
 }


### PR DESCRIPTION
**Fixes flarum/core#2943**

Required relation for proper tag listing, should have been done with https://github.com/flarum/tags/commit/df853dc528198614e6e45136a5912b98bb19ec0f. 