### PR TITLE
Eager load actor tag states

### DIFF
--- a/src/LoadForumTagsRelationship.php
+++ b/src/LoadForumTagsRelationship.php
@@ -42,6 +42,7 @@ class LoadForumTagsRelationship
                     ->limit(4) // We get one more than we need so the "more" link can be shown.
             )
             ->whereVisibleTo($actor)
+            ->withStateFor($actor)
             ->get();
     }
 }

--- a/src/Tag.php
+++ b/src/Tag.php
@@ -34,6 +34,7 @@ use Illuminate\Database\Eloquent\Builder;
  * @property int $last_posted_discussion_id
  * @property int $last_posted_user_id
  * @property string $icon
+ * @property TagState
  */
 class Tag extends AbstractModel
 {


### PR DESCRIPTION
This was lost in the 1.0 performance refactor and is necessary especially for extensions using the tag state.

**Relevent PR: **
**Relevent Commit: github.com/flarum/tags/commit/39e4649f8f38b0d3a7bdc0288e3cc286aae4556c#diff-85fcc43f76b087c419a3e0c8e15907ae6164312e492cb483cd9542197b2f102a**