### PR TITLE
Exported (compat) `getSelectableTags` utils

### DIFF
--- a/js/src/forum/compat.js
+++ b/js/src/forum/compat.js
@@ -10,6 +10,7 @@ import TagLinkButton from './components/TagLinkButton';
 import addTagList from './addTagList';
 import addTagLabels from './addTagLabels';
 import addTagComposer from './addTagComposer';
+import getSelectableTags from './utils/getSelectableTags';
 
 export default Object.assign(compat, {
   'tags/addTagFilter': addTagFilter,
@@ -22,4 +23,5 @@ export default Object.assign(compat, {
   'tags/addTagList': addTagList,
   'tags/addTagLabels': addTagLabels,
   'tags/addTagComposer': addTagComposer,
+  'tags/utils/getSelectableTags': getSelectableTags,
 });


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
Added missing export to the forum compat.js file: `getSelectableTags` utils.

**Reviewers should focus on:**
If export works fine and doesn't breaks anything.

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.