### PR TITLE
Fix unauthorized view of restricted tags

### DIFF
--- a/src/Api/Controller/ListTagsController.php
+++ b/src/Api/Controller/ListTagsController.php
@@ -12,7 +12,7 @@ namespace Flarum\Tags\Api\Controller;
 use Flarum\Api\Controller\AbstractListController;
 use Flarum\Http\RequestUtil;
 use Flarum\Tags\Api\Serializer\TagSerializer;
-use Flarum\Tags\Tag;
+use Flarum\Tags\TagRepository;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
 
@@ -40,14 +40,11 @@ class ListTagsController extends AbstractListController
     ];
 
     /**
-     * @var \Flarum\Tags\Tag
+     * @var TagRepository
      */
     protected $tags;
 
-    /**
-     * @param \Flarum\Tags\Tag $tags
-     */
-    public function __construct(Tag $tags)
+    public function __construct(TagRepository $tags)
     {
         $this->tags = $tags;
     }
@@ -64,8 +61,10 @@ class ListTagsController extends AbstractListController
             $include = array_merge($include, ['lastPostedDiscussion.tags', 'lastPostedDiscussion.state']);
         }
 
-        $tags = $this->tags->whereVisibleTo($actor)->withStateFor($actor)->get();
-
-        return $tags->load($include);
+        return $this->tags
+            ->with($include, $actor)
+            ->whereVisibleTo($actor)
+            ->withStateFor($actor)
+            ->get();
     }
 }

--- a/src/Api/Controller/ShowTagController.php
+++ b/src/Api/Controller/ShowTagController.php
@@ -12,7 +12,7 @@ namespace Flarum\Tags\Api\Controller;
 use Flarum\Api\Controller\AbstractShowController;
 use Flarum\Http\RequestUtil;
 use Flarum\Tags\Api\Serializer\TagSerializer;
-use Flarum\Tags\Tag;
+use Flarum\Tags\TagRepository;
 use Illuminate\Support\Arr;
 use Psr\Http\Message\ServerRequestInterface;
 use Tobscure\JsonApi\Document;
@@ -32,11 +32,11 @@ class ShowTagController extends AbstractShowController
     ];
 
     /**
-     * @var Tag
+     * @var TagRepository
      */
     private $tags;
 
-    public function __construct(Tag $tags)
+    public function __construct(TagRepository $tags)
     {
         $this->tags = $tags;
     }
@@ -51,8 +51,8 @@ class ShowTagController extends AbstractShowController
         $include = $this->extractInclude($request);
 
         return $this->tags
+            ->with($include, $actor)
             ->whereVisibleTo($actor)
-            ->with($include)
             ->where('slug', $slug)
             ->firstOrFail();
     }

--- a/tests/integration/api/tags/ListTest.php
+++ b/tests/integration/api/tags/ListTest.php
@@ -85,6 +85,33 @@ class ListTest extends TestCase
     /**
      * @test
      */
+    public function user_sees_where_allowed_with_included_tags()
+    {
+        $response = $this->send(
+            $this->request('GET', '/api/tags', [
+                'authenticatedAs' => 2,
+            ])->withQueryParams([
+                'include' => 'children'
+            ])
+        );
+
+        $this->assertEquals(200, $response->getStatusCode());
+
+        $responseBody = json_decode($response->getBody()->getContents(), true);
+
+        $data = $responseBody['data'];
+        $included = $responseBody['included'];
+
+        // 5 isnt included because parent access doesnt necessarily give child access
+        // 6, 7, 8 aren't included because child access shouldnt work unless parent
+        // access is also given.
+        $this->assertEquals(['1', '2', '3', '4', '9', '10', '11'], Arr::pluck($data, 'id'));
+        $this->assertEquals(['3', '4'], Arr::pluck($included, 'id'));
+    }
+
+    /**
+     * @test
+     */
     public function guest_cant_see_restricted_or_children_of_restricted()
     {
         $response = $this->send(


### PR DESCRIPTION
**Fixes flarum/core#3050**

**Changes proposed in this pull request:**
The tags in question could be seen because they were loaded as included relations, which didn't go through any visibility checks and therefore ended up in the response.

**Confirmed**
- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
