### PR TITLE
Lazy load tags in DiscussionTaggedPost if necessary

### DIFF
--- a/src/Api/Controller/ShowTagController.php
+++ b/src/Api/Controller/ShowTagController.php
@@ -53,7 +53,7 @@ class ShowTagController extends AbstractShowController
         return $this->tags
             ->with($include, $actor)
             ->whereVisibleTo($actor)
-            ->where(function($query) use ($slug) {
+            ->where(function ($query) use ($slug) {
                 $query->where('slug', $slug)
                 ->orWhere('id', $slug);
             })

--- a/src/Api/Controller/ShowTagController.php
+++ b/src/Api/Controller/ShowTagController.php
@@ -53,7 +53,10 @@ class ShowTagController extends AbstractShowController
         return $this->tags
             ->with($include, $actor)
             ->whereVisibleTo($actor)
-            ->where('slug', $slug)
+            ->where(function($query) use ($slug) {
+                $query->where('slug', $slug)
+                ->orWhere('id', $slug);
+            })
             ->firstOrFail();
     }
 }


### PR DESCRIPTION
Closes flarum/core#3043

Depends on flarum/core#3100

Before: https://i.imgur.com/TaYra03.png

After: https://i.imgur.com/VB0GAVq.png

**Questions for Reviewers**

The `ShowTagController` change introduces ambiguity for fetching by ID vs slug, but I'm not sure that's avoidable, as the alternative is a `bySlug` query parameter, which would be a breaking change.