### PR TITLE
Basic validation for tags slugs

### DIFF
--- a/src/TagValidator.php
+++ b/src/TagValidator.php
@@ -18,7 +18,7 @@ class TagValidator extends AbstractValidator
      */
     protected $rules = [
         'name' => ['required'],
-        'slug' => ['required', 'unique:tags', 'regex:/^[^\/ ]*$/i'],
+        'slug' => ['required', 'unique:tags', 'regex:/^[^\/\\ ]*$/i'],
         'is_hidden' => ['bool'],
         'description' => ['string', 'max:700'],
         'color' => ['regex:/^#([a-f0-9]{6}|[a-f0-9]{3})$/i'],

--- a/src/TagValidator.php
+++ b/src/TagValidator.php
@@ -18,7 +18,7 @@ class TagValidator extends AbstractValidator
      */
     protected $rules = [
         'name' => ['required'],
-        'slug' => ['required', 'unique:tags'],
+        'slug' => ['required', 'unique:tags', 'regex:/^[^\/ ]*$/i'],
         'is_hidden' => ['bool'],
         'description' => ['string', 'max:700'],
         'color' => ['regex:/^#([a-f0-9]{6}|[a-f0-9]{3})$/i'],


### PR DESCRIPTION
**Fixes https://github.com/flarum/core/issues/3152**

**Changes proposed in this pull request:**
Validate tags slugs to ensure they don't contain slashes or spaces.

**Reviewers should focus on:**
I kept the requirements minimal for now, we can revisit additional constraints later if needed.

Unfortunately, even though the backend validation works, a `422` message won't actually be shown. This is because of https://github.com/flarum/core/issues/3154.


**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [x] Backend changes: tests are green (run `composer test`).
- [x] Core developer confirmed locally this works as intended.
- [x] Tests have been added, or are not appropriate here.
