### PR TITLE
perf: Fix eager loading of tag state relation in other endpoints

### DIFF
--- a/extend.php
+++ b/extend.php
@@ -31,6 +31,12 @@ use Flarum\Tags\Query\TagFilterGambit;
 use Flarum\Tags\Tag;
 use Psr\Http\Message\ServerRequestInterface;
 
+$eagerLoadTagState = function ($query, ?ServerRequestInterface $request, array $relations) {
+    if ($request && in_array('tags.state', $relations, true)) {
+        $query->withStateFor(RequestUtil::getActor($request));
+    }
+};
+
 return [
     (new Extend\Frontend('forum'))
         ->js(__DIR__.'/js/dist/forum.js')
@@ -73,17 +79,15 @@ return [
 
     (new Extend\ApiController(FlarumController\ListDiscussionsController::class))
         ->addInclude(['tags', 'tags.state', 'tags.parent'])
-        ->loadWhere('tags', function ($query, ?ServerRequestInterface $request, array $relations) {
-            if ($request && in_array('tags.state', $relations, true)) {
-                $query->withStateFor(RequestUtil::getActor($request));
-            }
-        }),
+        ->loadWhere('tags', $eagerLoadTagState),
 
     (new Extend\ApiController(FlarumController\ShowDiscussionController::class))
-        ->addInclude(['tags', 'tags.state', 'tags.parent']),
+        ->addInclude(['tags', 'tags.state', 'tags.parent'])
+        ->loadWhere('tags', $eagerLoadTagState),
 
     (new Extend\ApiController(FlarumController\CreateDiscussionController::class))
-        ->addInclude(['tags', 'tags.state', 'tags.parent']),
+        ->addInclude(['tags', 'tags.state', 'tags.parent'])
+        ->loadWhere('tags', $eagerLoadTagState),
 
     (new Extend\ApiController(FlarumController\ShowForumController::class))
         ->addInclude(['tags', 'tags.parent'])


### PR DESCRIPTION
**Related to flarum/core#3191**

**Changes proposed in this pull request:**
Similarily to #149 we need to do the same for the other discussion endpoints, show and create, the impact is only noticeable with forums with very large number of users/activity.
