### PR TITLE
Use `ColorPreviewInput` in the `EditTagModal`

### DIFF
--- a/js/src/admin/components/EditTagModal.js
+++ b/js/src/admin/components/EditTagModal.js
@@ -1,8 +1,10 @@
-import Modal from 'flarum/components/Modal';
-import Button from 'flarum/components/Button';
-import ItemList from 'flarum/utils/ItemList';
-import { slug } from 'flarum/utils/string';
-import Stream from 'flarum/utils/Stream';
+import app from 'flarum/admin/app';
+import Modal from 'flarum/common/components/Modal';
+import Button from 'flarum/common/components/Button';
+import ColorPreviewInput from 'flarum/common/components/ColorPreviewInput';
+import ItemList from 'flarum/common/utils/ItemList';
+import { slug } from 'flarum/common/utils/string';
+import Stream from 'flarum/common/utils/Stream';
 
 import tagLabel from '../../common/helpers/tagLabel';
 
@@ -68,7 +70,7 @@ export default class EditTagModal extends Modal {
 
     items.add('color', <div className="Form-group">
       <label>{app.translator.trans('flarum-tags.admin.edit_tag.color_label')}</label>
-      <input className="FormControl" placeholder="#aaaaaa" bidi={this.color} />
+      <ColorPreviewInput className="FormControl" placeholder="#aaaaaa" bidi={this.color} />
     </div>, 20);
 
     items.add('icon', <div className="Form-group">


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Changes proposed in this pull request:**
<!-- fill this out, mention the pages and/or components which have been impacted -->
This PR replaces a plain text input with a `<ColorPreviewInput />`, so that users can see if they entered the color correctly.

**Screenshot**
<!-- include an image of the most relevant user-facing change, if any -->
![image](https://user-images.githubusercontent.com/25438601/151646415-aa0c1231-46bb-4786-865f-84bd93100a56.png)
![image](https://user-images.githubusercontent.com/25438601/151646611-d5eba885-6d88-4754-9501-017519f25763.png)

**Necessity**

- [x] Has the problem that is being solved here been clearly explained?
- [x] If applicable, have various options for solving this problem been considered?
- [x] For core PRs, does this need to be in core, or could it be in an extension?
- [x] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [x] Frontend changes: tested on a local Flarum installation.
- [ ] Core developer confirmed locally this works as intended.