### PR TITLE
Fix mobile Safari tag alignment

### DIFF
--- a/less/common/TagLabel.less
+++ b/less/common/TagLabel.less
@@ -7,6 +7,7 @@
   background: var(--tag-bg);
   color: var(--tag-color);
   text-transform: none;
+  vertical-align: bottom;
 
   &.untagged {
     --tag-bg: transparent;


### PR DESCRIPTION
<!--
IMPORTANT: We applaud pull requests, they excite us every single time. As we have an obligation to maintain a healthy code standard and quality, we take sufficient time for reviews. Please do create a separate pull request per change/issue/feature; we will ask you to split bundled pull requests.
-->

**Fixes [#3245](https://github.com/flarum/core/issues/3245)**

This shows 2 commits but you will see only 1 file change and in that file only 1 line change. 

**Changes proposed in this pull request:**
Add vertical-align bottom to tag label less file. Fixes misalignment issue only in mobile Safari. This does not change anything in other browsers. 

**Reviewers should focus on:**
Notice that on a PC or non-Safari browser nothing changes. But, if you have an iPhone you will notice no more tag alignment issues. 

**Screenshot**
Screenshot is in issue reported. Please see issue. 


**Necessity**

- [ ] Has the problem that is being solved here been clearly explained?
- [ ] If applicable, have various options for solving this problem been considered?
- [ ] For core PRs, does this need to be in core, or could it be in an extension?
- [ ] Are we willing to maintain this for years / potentially forever?

**Confirmed**

- [ ] Frontend changes: tested on a local Flarum installation.
- [ ] Backend changes: tests are green (run `composer test`).
- [ ] Core developer confirmed locally this works as intended.
- [ ] Tests have been added, or are not appropriate here.

**Required changes:**

- [ ] Related documentation PR: (Remove if irrelevant)
- [ ] Related core extension PRs: (Remove if irrelevant)
